### PR TITLE
ignore changes to master_password

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -51,7 +51,7 @@ resource "aws_redshift_cluster" "this" {
   tags = "${var.tags}"
 
   lifecycle {
-    ignore_changes = [ "${var.ignored_changes}" ]
+    ignore_changes = [ "master_password" ]
   }
 
 }

--- a/main.tf
+++ b/main.tf
@@ -49,6 +49,11 @@ resource "aws_redshift_cluster" "this" {
   }
 
   tags = "${var.tags}"
+
+  lifecycle {
+    ignore_changes = [ "${var.ignored_changes}" ]
+  }
+
 }
 
 resource "aws_redshift_parameter_group" "this" {

--- a/variables.tf
+++ b/variables.tf
@@ -136,3 +136,9 @@ variable "allow_version_upgrade" {
   description = "(Optional) If true, major version upgrades can be applied during the maintenance window to the Amazon Redshift engine that is running on the cluster."
   default     = true
 }
+
+variable "ignored_changes" {
+  description = "(Optional) A list of aws_redshift_cluster arguments that ignored if they change external to this module, e.g. master_password"
+  type = "list"
+  default = []
+}

--- a/variables.tf
+++ b/variables.tf
@@ -136,9 +136,3 @@ variable "allow_version_upgrade" {
   description = "(Optional) If true, major version upgrades can be applied during the maintenance window to the Amazon Redshift engine that is running on the cluster."
   default     = true
 }
-
-variable "ignored_changes" {
-  description = "(Optional) A list of aws_redshift_cluster arguments that ignored if they change external to this module, e.g. master_password"
-  type = "list"
-  default = []
-}


### PR DESCRIPTION
ignoring changes to `master_password` is a good pattern because it allows you to create a cluster with an initial password and then update the password via the console to something secure that's not stored in the plaintext state files.

ideally this would be a configurable option, but terraform doesn't allow variable interpolation in `ignore_changes`.   i.e. this doesn't work:

```
variable "ignore_changes" {
  type = "list"
  default = []
}

[...]

lifecycle {
  ignore_changes = [ "${var.ignore_changes}" ]
}
```

see https://github.com/hashicorp/terraform/issues/3116 for more info on that.



