### PR TITLE
New Feature: Restore Redshift from Snapshot

### DIFF
--- a/.whitesource
+++ b/.whitesource
@@ -1,8 +1,0 @@
-##########################################################
-####    WhiteSource Integration configuration file    ####
-##########################################################
-
-# Configuration #
-#---------------#
-ws.repo.scan=true
-vulnerable.check.run.conclusion.level=failure

--- a/.whitesource
+++ b/.whitesource
@@ -1,0 +1,8 @@
+##########################################################
+####    WhiteSource Integration configuration file    ####
+##########################################################
+
+# Configuration #
+#---------------#
+ws.repo.scan=true
+vulnerable.check.run.conclusion.level=failure

--- a/README.md
+++ b/README.md
@@ -68,6 +68,8 @@ module "redshift" {
 | redshift\_subnet\_group\_name | The name of a cluster subnet group to be associated with this cluster. If not specified, new subnet will be created. | string | `""` | no |
 | require\_ssl | Require SSL to connect to this cluster | string | `"false"` | no |
 | skip\_final\_snapshot | If true (default), no snapshot will be made before deleting DB | string | `"true"` | no |
+| snapshot_identifier | (Optional) The name of the snapshot from which to create the new cluster. | string | `""` | no |
+| snapshot_cluster_identifier | (Optional) The name of the cluster the source snapshot was created from. | string | `""` | no |
 | subnets | List of subnets DB should be available at. It might be one subnet. | list | `[]` | no |
 | tags | A mapping of tags to assign to all resources | map | `{}` | no |
 | use\_fips\_ssl | Enable FIPS-compliant SSL mode only if your system is required to be FIPS compliant. | string | `"false"` | no |

--- a/main.tf
+++ b/main.tf
@@ -25,6 +25,10 @@ resource "aws_redshift_cluster" "this" {
 
   publicly_accessible = "${var.publicly_accessible}"
 
+  # Restore from snapshot
+  snapshot_identifier                 = "${var.snapshot_identifier}"
+  snapshot_cluster_identifier         = "${var.snapshot_cluster_identifier}"
+
   # Snapshots and backups
   final_snapshot_identifier           = "${var.final_snapshot_identifier}"
   skip_final_snapshot                 = "${var.skip_final_snapshot}"

--- a/variables.tf
+++ b/variables.tf
@@ -120,6 +120,16 @@ variable "require_ssl" {
   default     = "false"
 }
 
+variable "snapshot_identifier" {
+  description = "(Optional) The name of the snapshot from which to create the new cluster."
+  default     = ""
+}
+
+variable "snapshot_cluster_identifier" {
+  description = "(Optional) The name of the cluster the source snapshot was created from."
+  default     = ""
+}
+
 variable "use_fips_ssl" {
   description = "Enable FIPS-compliant SSL mode only if your system is required to be FIPS compliant."
   default     = "false"


### PR DESCRIPTION
This PR adds the following new feature:

- Restore Redshift from Snapshot

Note: If the user doesn't want to restore Redshift from a snapshot, then leaving `snapshot_identifier` and `snapshot_cluster_identifier` variables empty is enough.