### PR TITLE
Add Redshift cluster ARN to output

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -1,3 +1,8 @@
+output "this_redshift_cluster_arn" {
+  description = "The Redshift cluster ARN"
+  value       = aws_redshift_cluster.this.arn
+}
+
 output "this_redshift_cluster_id" {
   description = "The Redshift cluster ID"
   value       = aws_redshift_cluster.this.id


### PR DESCRIPTION
# Description

Adds the Redshift cluster ARN to the output.

I needed this to retrieve the ARN for an AWS Lambda IAM role.