### PR TITLE
Fix type error in final_snapshot_identifier variable

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -88,8 +88,8 @@ variable "vpc_security_group_ids" {
 
 variable "final_snapshot_identifier" {
   description = "(Optional) The identifier of the final snapshot that is to be created immediately before deleting the cluster. If this parameter is provided, 'skip_final_snapshot' must be false."
-  type        = bool
-  default     = false
+  type        = string
+  default     = ""
 }
 
 variable "skip_final_snapshot" {


### PR DESCRIPTION
This bug is keeping this module from working with Terraform 0.12 when `final_snapshot_identifier` is specified.  This identifier should be a string, not a true/false boolean value.