### PR TITLE
[ADD] missing owner_account var for restoring from cross-account shar…

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -34,6 +34,7 @@ resource "aws_redshift_cluster" "this" {
   # Restore from snapshot
   snapshot_identifier         = var.snapshot_identifier
   snapshot_cluster_identifier = var.snapshot_cluster_identifier
+  owner_account               = var.owner_account
 
   # Snapshots and backups
   final_snapshot_identifier           = var.final_snapshot_identifier

--- a/variables.tf
+++ b/variables.tf
@@ -154,6 +154,12 @@ variable "snapshot_cluster_identifier" {
   default     = null
 }
 
+variable "owner_account" {
+  description = "(Optional) The AWS customer account used to create or copy the snapshot. Required if you are restoring a snapshot you do not own, optional if you own the snapshot."
+  type        = string
+  default     = null
+}
+
 variable "use_fips_ssl" {
   description = "Enable FIPS-compliant SSL mode only if your system is required to be FIPS compliant."
   type        = string


### PR DESCRIPTION
…ed shapshot

# Description

The "owner_account" var is needed to be specified when the snapshot is shared from different AWS account.
https://github.com/hashicorp/terraform/pull/12062
https://www.terraform.io/docs/providers/aws/r/redshift_cluster.html
