### PR TITLE
Changing wlm_json_configuration to be list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 <a name="unreleased"></a>
 ## [Unreleased]
 
-
+- Added a list input for wlm_configuration ([#26](https://github.com/terraform-aws-modules/terraform-aws-redshift/pull/26))
 
 <a name="v2.2.0"></a>
 ## [v2.2.0] - 2019-11-02

--- a/main.tf
+++ b/main.tf
@@ -74,7 +74,7 @@ resource "aws_redshift_parameter_group" "this" {
 
   parameter {
     name  = "wlm_json_configuration"
-    value = var.wlm_json_configuration
+    value = jsonencode(var.wlm_configuration)
   }
 
   parameter {

--- a/main.tf
+++ b/main.tf
@@ -74,7 +74,7 @@ resource "aws_redshift_parameter_group" "this" {
 
   parameter {
     name  = "wlm_json_configuration"
-    value = jsonencode(var.wlm_configuration)
+    value = length(var.wlm_configuration) > 0 ? jsonencode(var.wlm_configuration) : var.wlm_json_configuration
   }
 
   parameter {

--- a/variables.tf
+++ b/variables.tf
@@ -163,8 +163,14 @@ variable "use_fips_ssl" {
 
 variable "wlm_configuration" {
   description = "Configuration bits for WLM json. see https://docs.aws.amazon.com/redshift/latest/mgmt/workload-mgmt-config.html"
-  type        = map(string)
-  default     = [{ query_concurrency = 5 }]
+  type        = list(map(any))
+  default     = []
+}
+
+variable "wlm_json_configuration" {
+  description = "Configuration bits for WLM json. see https://docs.aws.amazon.com/redshift/latest/mgmt/workload-mgmt-config.html"
+  type        = string
+  default     = "[{\"query_concurrency\": 5}]"
 }
 
 variable "tags" {

--- a/variables.tf
+++ b/variables.tf
@@ -161,10 +161,10 @@ variable "use_fips_ssl" {
   default     = "false"
 }
 
-variable "wlm_json_configuration" {
+variable "wlm_configuration" {
   description = "Configuration bits for WLM json. see https://docs.aws.amazon.com/redshift/latest/mgmt/workload-mgmt-config.html"
-  type        = string
-  default     = "[{\"query_concurrency\": 5}]"
+  type        = map(string)
+  default     = [{ query_concurrency = 5 }]
 }
 
 variable "tags" {


### PR DESCRIPTION
# Description

Having a long one line json in terraform is not very intuitive. having the configuration as HCL is more readable.
