### PR TITLE
feat: allow AWS provider 3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,14 +49,14 @@ module "redshift" {
 
 | Name | Version |
 |------|---------|
-| terraform | ~> 0.12.6 |
-| aws | ~> 2.25 |
+| terraform | >= 0.12.6, < 0.14 |
+| aws | >= 2.25, < 4.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | ~> 2.25 |
+| aws | >= 2.25, < 4.0 |
 
 ## Inputs
 

--- a/versions.tf
+++ b/versions.tf
@@ -1,7 +1,7 @@
 terraform {
-  required_version = "~> 0.12.6"
+  required_version = ">= 0.12.6, < 0.14"
 
   required_providers {
-    aws = "~> 3.0"
+    aws = ">= 2.25, < 4.0"
   }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -2,6 +2,6 @@ terraform {
   required_version = "~> 0.12.6"
 
   required_providers {
-    aws = "~> 2.25"
+    aws = "~> 3.0"
   }
 }


### PR DESCRIPTION
## Description
Updates to AWS provider 3.0 with respective syntax. Closes #42

## Motivation and Context
Can't upgrade to 3.0 AWS provider in modules that import this module. Version conflict.

## Breaking Changes
Major compatibility break, to align with v3.0 of AWS provider.

## How Has This Been Tested?
Ran `terraform plan` overriding provider URL in Honeycomb's invocation of redshift module.