### PR TITLE
fix: Allow omit of final_snapshot_identifier

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -37,7 +37,7 @@ resource "aws_redshift_cluster" "this" {
   owner_account               = var.owner_account
 
   # Snapshots and backups
-  final_snapshot_identifier           = var.final_snapshot_identifier
+  final_snapshot_identifier           = var.skip_final_snapshot ? null : var.final_snapshot_identifier
   skip_final_snapshot                 = var.skip_final_snapshot
   automated_snapshot_retention_period = var.automated_snapshot_retention_period
   preferred_maintenance_window        = var.preferred_maintenance_window


### PR DESCRIPTION
Resolves #39 

Defaulting final_snapshot_identifier to null if skip_final_snapshot is true

Ready to be merged

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
