### PR TITLE
feat: make max concurrency scaling configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ module "redshift" {
 | kms\_key\_id | (Optional) The ARN for the KMS encryption key. When specifying kms\_key\_id, encrypted needs to be set to true. | `string` | `""` | no |
 | logging\_bucket\_name | (Optional, required when enable\_logging is true) The name of an existing S3 bucket where the log files are to be stored. Must be in the same region as the cluster and the cluster must have read bucket and put object permissions. | `string` | `null` | no |
 | logging\_s3\_key\_prefix | (Optional) The prefix applied to the log file names. | `string` | `null` | no |
+| max\_concurrency\_scaling\_clusters | (Optional) Max concurrency scaling clusters parameter (0 to 10) | `string` | `1` | no |
 | owner\_account | (Optional) The AWS customer account used to create or copy the snapshot. Required if you are restoring a snapshot you do not own, optional if you own the snapshot. | `string` | `null` | no |
 | parameter\_group\_name | The name of the parameter group to be associated with this cluster. If not specified new parameter group will be created. | `string` | `""` | no |
 | preferred\_maintenance\_window | When AWS can run snapshot, can't overlap with maintenance window | `string` | `"sat:10:00-sat:10:30"` | no |

--- a/main.tf
+++ b/main.tf
@@ -104,6 +104,12 @@ resource "aws_redshift_parameter_group" "this" {
     value = var.enable_user_activity_logging
   }
 
+  parameter {
+    # ref: https://docs.aws.amazon.com/redshift/latest/dg/concurrency-scaling.html
+    name  = "max_concurrency_scaling_clusters"
+    value = var.max_concurrency_scaling_clusters
+  }
+
   tags = var.tags
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -208,3 +208,9 @@ variable "allow_version_upgrade" {
   type        = bool
   default     = true
 }
+
+variable "max_concurrency_scaling_clusters" {
+  description = "(Optional) Max concurrency scaling clusters parameter (0 to 10)"
+  type        = string
+  default     = "1"
+}


### PR DESCRIPTION
## Description
Make [max_concurrency_scaling_clusters](https://docs.aws.amazon.com/redshift/latest/dg/r_max_concurrency_scaling_clusters.html) configurable

## Motivation and Context
With current module implementation manual change of `max_concurrency)scaling_clusters` parameter will be reverted by Terraform on next run.

[Concurrency scaling](https://docs.aws.amazon.com/redshift/latest/dg/concurrency-scaling.html) is a nice Redshift feature allowing to handle spikes without cluster over-provision. Definitely deserved to be configurable by the module.

## Breaking Changes
No breaking changes.
Default parameter value set to `1` that match parameter group defaults.

## How Has This Been Tested?
Been tested with new and existing clusters.
Following update plan is generated:
```
    + parameter {
          + name  = "max_concurrency_scaling_clusters"
          + value = "1"
        }
```