### PR TITLE
feat: add elastic_ip parameter

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -30,6 +30,7 @@ resource "aws_redshift_cluster" "this" {
   cluster_parameter_group_name = local.parameter_group_name
 
   publicly_accessible = var.publicly_accessible
+  elastic_ip          = var.elastic_ip
 
   # Restore from snapshot
   snapshot_identifier         = var.snapshot_identifier

--- a/variables.tf
+++ b/variables.tf
@@ -221,3 +221,9 @@ variable "max_concurrency_scaling_clusters" {
   type        = string
   default     = "1"
 }
+
+variable "elastic_ip" {
+  description = "(Optional) The Elastic IP (EIP) address for the cluster."
+  type        = string
+  default     = null
+}


### PR DESCRIPTION
## Description
Add elastic_ip parameter (https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/redshift_cluster#elastic_ip)

## Motivation and Context
We required setting an IP for Tableau integration.

## Breaking Changes
No

## How Has This Been Tested?
Used in production at my employer.
