### PR TITLE
docs: Add ra3 node options to cluster_node_type valid values

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -14,7 +14,7 @@ variable "cluster_version" {
 variable "cluster_node_type" {
   description = "Node Type of Redshift cluster"
   type        = string
-  # Valid Values: dc1.large | dc1.8xlarge | dc2.large | dc2.8xlarge | ds2.xlarge | ds2.8xlarge.
+  # Valid Values: dc1.large | dc1.8xlarge | dc2.large | dc2.8xlarge | ds2.xlarge | ds2.8xlarge | ra3.xlplus | ra3.4xlarge | ra3.16xlarge.
   # http://docs.aws.amazon.com/cli/latest/reference/redshift/create-cluster.html
 }
 


### PR DESCRIPTION
## Description
Adding additional supported node types to `cluster_node_type` variable to match existing documentation

## Motivation and Context
This change removes any confusion as to which node types are valid when populating `cluster_node_type`

## Breaking Changes
Documentation only change

## How Has This Been Tested?
This change provides clearer documentation for the variable `cluster_node_type`
There are no changes in implementation
