### PR TITLE
feat: Add redshift_cluster_nodes to the outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ No modules.
 | <a name="output_redshift_cluster_security_groups"></a> [redshift\_cluster\_security\_groups](#output\_redshift\_cluster\_security\_groups) | The security groups associated with the cluster |
 | <a name="output_redshift_cluster_subnet_group_name"></a> [redshift\_cluster\_subnet\_group\_name](#output\_redshift\_cluster\_subnet\_group\_name) | The name of a cluster subnet group to be associated with this cluster |
 | <a name="output_redshift_cluster_type"></a> [redshift\_cluster\_type](#output\_redshift\_cluster\_type) | The Redshift cluster type |
+| <a name="output_redshift_cluster_nodes"></a> [redshift\_cluster\_nodes](#output\_redshift\_cluster\_nodes) | Cluster nodes details |
 | <a name="output_redshift_cluster_version"></a> [redshift\_cluster\_version](#output\_redshift\_cluster\_version) | The version of Redshift engine software |
 | <a name="output_redshift_cluster_vpc_security_group_ids"></a> [redshift\_cluster\_vpc\_security\_group\_ids](#output\_redshift\_cluster\_vpc\_security\_group\_ids) | The VPC security group ids associated with the cluster |
 | <a name="output_redshift_parameter_group_id"></a> [redshift\_parameter\_group\_id](#output\_redshift\_parameter\_group\_id) | The ID of Redshift parameter group created by this module |

--- a/outputs.tf
+++ b/outputs.tf
@@ -111,3 +111,8 @@ output "redshift_parameter_group_id" {
   description = "The ID of Redshift parameter group created by this module"
   value       = element(concat(aws_redshift_parameter_group.this.*.id, [""]), 0)
 }
+
+output "redshift_cluster_nodes" {
+  description = "Cluster nodes in the Redshift cluster"
+  value       = aws_redshift_cluster.this.cluster_nodes
+}

--- a/versions.tf
+++ b/versions.tf
@@ -2,6 +2,6 @@ terraform {
   required_version = ">= 0.12.31"
 
   required_providers {
-    aws = ">= 2.25"
+    aws = ">= 3.57.0"
   }
 }


### PR DESCRIPTION
With new AWS 3.57.0 provider - new output for Redshift has been added - `redshift_cluster_nodes` - it's available now to fetch IP addresses for nodes. 

https://github.com/hashicorp/terraform-provider-aws/blob/v3.57.0/CHANGELOG.md