### PR TITLE
feat!: Add new resources introduces in provider version 4.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,14 +37,15 @@ module "redshift" {
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.31 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.57.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.6 |
+| <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.57.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.6 |
 
 ## Modules
 
@@ -54,81 +55,109 @@ No modules.
 
 | Name | Type |
 |------|------|
+| [aws_iam_role.scheduled_action](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_redshift_cluster.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/redshift_cluster) | resource |
 | [aws_redshift_parameter_group.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/redshift_parameter_group) | resource |
+| [aws_redshift_scheduled_action.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/redshift_scheduled_action) | resource |
+| [aws_redshift_snapshot_schedule.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/redshift_snapshot_schedule) | resource |
+| [aws_redshift_snapshot_schedule_association.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/redshift_snapshot_schedule_association) | resource |
 | [aws_redshift_subnet_group.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/redshift_subnet_group) | resource |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_allow_version_upgrade"></a> [allow\_version\_upgrade](#input\_allow\_version\_upgrade) | (Optional) If true, major version upgrades can be applied during the maintenance window to the Amazon Redshift engine that is running on the cluster. | `bool` | `true` | no |
-| <a name="input_automated_snapshot_retention_period"></a> [automated\_snapshot\_retention\_period](#input\_automated\_snapshot\_retention\_period) | How long will we retain backups | `number` | `0` | no |
-| <a name="input_cluster_database_name"></a> [cluster\_database\_name](#input\_cluster\_database\_name) | The name of the database to create | `string` | n/a | yes |
-| <a name="input_cluster_iam_roles"></a> [cluster\_iam\_roles](#input\_cluster\_iam\_roles) | A list of IAM Role ARNs to associate with the cluster. A Maximum of 10 can be associated to the cluster at any time. | `list(string)` | `[]` | no |
-| <a name="input_cluster_identifier"></a> [cluster\_identifier](#input\_cluster\_identifier) | Custom name of the cluster | `string` | n/a | yes |
-| <a name="input_cluster_master_password"></a> [cluster\_master\_password](#input\_cluster\_master\_password) | Password for master user | `string` | n/a | yes |
-| <a name="input_cluster_master_username"></a> [cluster\_master\_username](#input\_cluster\_master\_username) | Master username | `string` | n/a | yes |
-| <a name="input_cluster_node_type"></a> [cluster\_node\_type](#input\_cluster\_node\_type) | Node Type of Redshift cluster | `string` | n/a | yes |
-| <a name="input_cluster_number_of_nodes"></a> [cluster\_number\_of\_nodes](#input\_cluster\_number\_of\_nodes) | Number of nodes in the cluster (values greater than 1 will trigger 'cluster\_type' of 'multi-node') | `number` | `3` | no |
-| <a name="input_cluster_parameter_group"></a> [cluster\_parameter\_group](#input\_cluster\_parameter\_group) | Parameter group, depends on DB engine used | `string` | `"redshift-1.0"` | no |
-| <a name="input_cluster_port"></a> [cluster\_port](#input\_cluster\_port) | Cluster port | `number` | `5439` | no |
-| <a name="input_cluster_version"></a> [cluster\_version](#input\_cluster\_version) | Version of Redshift engine cluster | `string` | `"1.0"` | no |
-| <a name="input_elastic_ip"></a> [elastic\_ip](#input\_elastic\_ip) | (Optional) The Elastic IP (EIP) address for the cluster. | `string` | `null` | no |
-| <a name="input_enable_case_sensitive_identifier"></a> [enable\_case\_sensitive\_identifier](#input\_enable\_case\_sensitive\_identifier) | (Optional) A configuration value that determines whether name identifiers of databases, tables, and columns are case sensitive. | `bool` | `false` | no |
-| <a name="input_enable_logging"></a> [enable\_logging](#input\_enable\_logging) | Enables logging information such as queries and connection attempts, for the specified Amazon Redshift cluster. | `bool` | `false` | no |
-| <a name="input_enable_user_activity_logging"></a> [enable\_user\_activity\_logging](#input\_enable\_user\_activity\_logging) | Enable logging of user activity. See https://docs.aws.amazon.com/redshift/latest/mgmt/db-auditing.html | `string` | `"false"` | no |
-| <a name="input_encrypted"></a> [encrypted](#input\_encrypted) | (Optional) If true , the data in the cluster is encrypted at rest. | `bool` | `false` | no |
-| <a name="input_enhanced_vpc_routing"></a> [enhanced\_vpc\_routing](#input\_enhanced\_vpc\_routing) | (Optional) If true, enhanced VPC routing is enabled. | `bool` | `false` | no |
-| <a name="input_final_snapshot_identifier"></a> [final\_snapshot\_identifier](#input\_final\_snapshot\_identifier) | (Optional) The identifier of the final snapshot that is to be created immediately before deleting the cluster. If this parameter is provided, 'skip\_final\_snapshot' must be false. | `string` | `""` | no |
-| <a name="input_kms_key_id"></a> [kms\_key\_id](#input\_kms\_key\_id) | (Optional) The ARN for the KMS encryption key. When specifying kms\_key\_id, encrypted needs to be set to true. | `string` | `""` | no |
-| <a name="input_logging_bucket_name"></a> [logging\_bucket\_name](#input\_logging\_bucket\_name) | (Optional, required when enable\_logging is true) The name of an existing S3 bucket where the log files are to be stored. Must be in the same region as the cluster and the cluster must have read bucket and put object permissions. | `string` | `null` | no |
-| <a name="input_logging_s3_key_prefix"></a> [logging\_s3\_key\_prefix](#input\_logging\_s3\_key\_prefix) | (Optional) The prefix applied to the log file names. | `string` | `null` | no |
-| <a name="input_max_concurrency_scaling_clusters"></a> [max\_concurrency\_scaling\_clusters](#input\_max\_concurrency\_scaling\_clusters) | (Optional) Max concurrency scaling clusters parameter (0 to 10) | `string` | `"1"` | no |
-| <a name="input_owner_account"></a> [owner\_account](#input\_owner\_account) | (Optional) The AWS customer account used to create or copy the snapshot. Required if you are restoring a snapshot you do not own, optional if you own the snapshot. | `string` | `null` | no |
-| <a name="input_parameter_group_name"></a> [parameter\_group\_name](#input\_parameter\_group\_name) | The name of the parameter group to be associated with this cluster. If not specified new parameter group will be created. | `string` | `""` | no |
-| <a name="input_preferred_maintenance_window"></a> [preferred\_maintenance\_window](#input\_preferred\_maintenance\_window) | When AWS can run snapshot, can't overlap with maintenance window | `string` | `"sat:10:00-sat:10:30"` | no |
-| <a name="input_publicly_accessible"></a> [publicly\_accessible](#input\_publicly\_accessible) | Determines if Cluster can be publicly available (NOT recommended) | `bool` | `false` | no |
-| <a name="input_redshift_subnet_group_name"></a> [redshift\_subnet\_group\_name](#input\_redshift\_subnet\_group\_name) | The name of a cluster subnet group to be associated with this cluster. If not specified, new subnet will be created. | `string` | `""` | no |
-| <a name="input_require_ssl"></a> [require\_ssl](#input\_require\_ssl) | Require SSL to connect to this cluster | `string` | `"false"` | no |
-| <a name="input_skip_final_snapshot"></a> [skip\_final\_snapshot](#input\_skip\_final\_snapshot) | If true (default), no snapshot will be made before deleting DB | `bool` | `true` | no |
-| <a name="input_snapshot_cluster_identifier"></a> [snapshot\_cluster\_identifier](#input\_snapshot\_cluster\_identifier) | (Optional) The name of the cluster the source snapshot was created from. | `string` | `null` | no |
-| <a name="input_snapshot_copy_destination_region"></a> [snapshot\_copy\_destination\_region](#input\_snapshot\_copy\_destination\_region) | (Optional) The name of the region where the snapshot will be copied. | `string` | `null` | no |
-| <a name="input_snapshot_copy_grant_name"></a> [snapshot\_copy\_grant\_name](#input\_snapshot\_copy\_grant\_name) | (Optional) The name of the grant in the destination region. Required if you have a KMS encrypted cluster. | `string` | `null` | no |
-| <a name="input_snapshot_identifier"></a> [snapshot\_identifier](#input\_snapshot\_identifier) | (Optional) The name of the snapshot from which to create the new cluster. | `string` | `null` | no |
-| <a name="input_subnets"></a> [subnets](#input\_subnets) | List of subnets DB should be available at. It might be one subnet. | `list(string)` | `[]` | no |
-| <a name="input_tags"></a> [tags](#input\_tags) | A mapping of tags to assign to all resources | `map(string)` | `{}` | no |
-| <a name="input_use_fips_ssl"></a> [use\_fips\_ssl](#input\_use\_fips\_ssl) | Enable FIPS-compliant SSL mode only if your system is required to be FIPS compliant. | `string` | `"false"` | no |
-| <a name="input_vpc_security_group_ids"></a> [vpc\_security\_group\_ids](#input\_vpc\_security\_group\_ids) | A list of Virtual Private Cloud (VPC) security groups to be associated with the cluster. | `list(string)` | n/a | yes |
-| <a name="input_wlm_json_configuration"></a> [wlm\_json\_configuration](#input\_wlm\_json\_configuration) | Configuration bits for WLM json. see https://docs.aws.amazon.com/redshift/latest/mgmt/workload-mgmt-config.html | `string` | `"[{\"query_concurrency\": 5}]"` | no |
+| <a name="input_allow_version_upgrade"></a> [allow\_version\_upgrade](#input\_allow\_version\_upgrade) | If true , major version upgrades can be applied during the maintenance window to the Amazon Redshift engine that is running on the cluster. Default is `true` | `bool` | `null` | no |
+| <a name="input_automated_snapshot_retention_period"></a> [automated\_snapshot\_retention\_period](#input\_automated\_snapshot\_retention\_period) | The number of days that automated snapshots are retained. If the value is 0, automated snapshots are disabled. Even if automated snapshots are disabled, you can still create manual snapshots when you want with create-cluster-snapshot. Default is 1 | `number` | `null` | no |
+| <a name="input_availability_zone"></a> [availability\_zone](#input\_availability\_zone) | The EC2 Availability Zone (AZ) in which you want Amazon Redshift to provision the cluster | `string` | `null` | no |
+| <a name="input_availability_zone_relocation_enabled"></a> [availability\_zone\_relocation\_enabled](#input\_availability\_zone\_relocation\_enabled) | If `true`, the cluster can be relocated to another availability zone, either automatically by AWS or when requested. Available for use on clusters from the RA3 instance family. | `bool` | `false` | no |
+| <a name="input_cluster_identifier"></a> [cluster\_identifier](#input\_cluster\_identifier) | The Cluster Identifier. Must be a lower case string | `string` | `""` | no |
+| <a name="input_cluster_security_groups"></a> [cluster\_security\_groups](#input\_cluster\_security\_groups) | A list of security groups to be associated with this cluster | `list(string)` | `null` | no |
+| <a name="input_cluster_timeouts"></a> [cluster\_timeouts](#input\_cluster\_timeouts) | Create, update, and delete timeout configurations for the cluster | `map(string)` | `{}` | no |
+| <a name="input_cluster_version"></a> [cluster\_version](#input\_cluster\_version) | The version of the Amazon Redshift engine software that you want to deploy on the cluster. The version selected runs on all the nodes in the cluster | `string` | `null` | no |
+| <a name="input_create"></a> [create](#input\_create) | Determines whether to create Redshift cluster and resources (affects all resources) | `bool` | `true` | no |
+| <a name="input_create_parameter_group"></a> [create\_parameter\_group](#input\_create\_parameter\_group) | Determines whether to create a parameter group or use existing | `bool` | `true` | no |
+| <a name="input_create_scheduled_action_iam_role"></a> [create\_scheduled\_action\_iam\_role](#input\_create\_scheduled\_action\_iam\_role) | Determines whether a scheduled action IAM role is created | `bool` | `false` | no |
+| <a name="input_create_snapshot_schedule"></a> [create\_snapshot\_schedule](#input\_create\_snapshot\_schedule) | Determines whether to create a snapshot schedule | `bool` | `false` | no |
+| <a name="input_create_subnet_group"></a> [create\_subnet\_group](#input\_create\_subnet\_group) | Determines whether to create a subnet group or use existing | `bool` | `true` | no |
+| <a name="input_database_name"></a> [database\_name](#input\_database\_name) | The name of the first database to be created when the cluster is created. If you do not provide a name, Amazon Redshift will create a default database called `dev` | `string` | `null` | no |
+| <a name="input_elastic_ip"></a> [elastic\_ip](#input\_elastic\_ip) | The Elastic IP (EIP) address for the cluster | `string` | `null` | no |
+| <a name="input_encrypted"></a> [encrypted](#input\_encrypted) | If true, the data in the cluster is encrypted at rest | `bool` | `null` | no |
+| <a name="input_enhanced_vpc_routing"></a> [enhanced\_vpc\_routing](#input\_enhanced\_vpc\_routing) | If `true`, enhanced VPC routing is enabled | `bool` | `null` | no |
+| <a name="input_final_snapshot_identifier"></a> [final\_snapshot\_identifier](#input\_final\_snapshot\_identifier) | The identifier of the final snapshot that is to be created immediately before deleting the cluster. If this parameter is provided, `skip_final_snapshot` must be `false` | `string` | `null` | no |
+| <a name="input_iam_role_description"></a> [iam\_role\_description](#input\_iam\_role\_description) | Description of the scheduled action IAM role | `string` | `null` | no |
+| <a name="input_iam_role_name"></a> [iam\_role\_name](#input\_iam\_role\_name) | Name to use on scheduled action IAM role created | `string` | `null` | no |
+| <a name="input_iam_role_path"></a> [iam\_role\_path](#input\_iam\_role\_path) | Scheduled action IAM role path | `string` | `null` | no |
+| <a name="input_iam_role_permissions_boundary"></a> [iam\_role\_permissions\_boundary](#input\_iam\_role\_permissions\_boundary) | ARN of the policy that is used to set the permissions boundary for the scheduled action IAM role | `string` | `null` | no |
+| <a name="input_iam_role_tags"></a> [iam\_role\_tags](#input\_iam\_role\_tags) | A map of additional tags to add to the scheduled action IAM role created | `map(string)` | `{}` | no |
+| <a name="input_iam_role_use_name_prefix"></a> [iam\_role\_use\_name\_prefix](#input\_iam\_role\_use\_name\_prefix) | Determines whether scheduled action the IAM role name (`iam_role_name`) is used as a prefix | `string` | `true` | no |
+| <a name="input_iam_roles"></a> [iam\_roles](#input\_iam\_roles) | A list of IAM Role ARNs to associate with the cluster. A Maximum of 10 can be associated to the cluster at any time | `list(string)` | `[]` | no |
+| <a name="input_kms_key_arn"></a> [kms\_key\_arn](#input\_kms\_key\_arn) | The ARN for the KMS encryption key. When specifying `kms_key_id`, `encrypted` needs to be set to `true` | `string` | `null` | no |
+| <a name="input_logging"></a> [logging](#input\_logging) | Logging configuration for the cluster | `map(string)` | `{}` | no |
+| <a name="input_master_password"></a> [master\_password](#input\_master\_password) | Password for the master DB user. (Required unless a `snapshot_identifier` is provided). Must contain at least 8 chars, one uppercase letter, one lowercase letter, and one number | `string` | `null` | no |
+| <a name="input_master_username"></a> [master\_username](#input\_master\_username) | Username for the master DB user (Required unless a `snapshot_identifier` is provided). Defaults to `awsuser` | `string` | `"awsuser"` | no |
+| <a name="input_node_type"></a> [node\_type](#input\_node\_type) | The node type to be provisioned for the cluster | `string` | `"dc2.large"` | no |
+| <a name="input_number_of_nodes"></a> [number\_of\_nodes](#input\_number\_of\_nodes) | Number of nodes in the cluster. Defaults to 1. Note: values greater than 1 will trigger `cluster_type` to switch to `multi-node` | `number` | `1` | no |
+| <a name="input_owner_account"></a> [owner\_account](#input\_owner\_account) | The AWS customer account used to create or copy the snapshot. Required if you are restoring a snapshot you do not own, optional if you own the snapshot | `string` | `null` | no |
+| <a name="input_parameter_group_description"></a> [parameter\_group\_description](#input\_parameter\_group\_description) | The description of the Redshift parameter group. Defaults to `Managed by Terraform` | `string` | `null` | no |
+| <a name="input_parameter_group_family"></a> [parameter\_group\_family](#input\_parameter\_group\_family) | The family of the Redshift parameter group | `string` | `"redshift-1.0"` | no |
+| <a name="input_parameter_group_name"></a> [parameter\_group\_name](#input\_parameter\_group\_name) | The name of the Redshift parameter group, existing or to be created | `string` | `null` | no |
+| <a name="input_parameter_group_parameters"></a> [parameter\_group\_parameters](#input\_parameter\_group\_parameters) | value | `map(any)` | `{}` | no |
+| <a name="input_parameter_group_tags"></a> [parameter\_group\_tags](#input\_parameter\_group\_tags) | Additional tags to add to the parameter group | `map(string)` | `{}` | no |
+| <a name="input_port"></a> [port](#input\_port) | The port number on which the cluster accepts incoming connections. Default port is 5439 | `number` | `null` | no |
+| <a name="input_preferred_maintenance_window"></a> [preferred\_maintenance\_window](#input\_preferred\_maintenance\_window) | The weekly time range (in UTC) during which automated cluster maintenance can occur. Format: `ddd:hh24:mi-ddd:hh24:mi` | `string` | `"sat:10:00-sat:10:30"` | no |
+| <a name="input_publicly_accessible"></a> [publicly\_accessible](#input\_publicly\_accessible) | If true, the cluster can be accessed from a public network | `bool` | `false` | no |
+| <a name="input_scheduled_actions"></a> [scheduled\_actions](#input\_scheduled\_actions) | Map of maps containing scheduled action defintions | `any` | `{}` | no |
+| <a name="input_skip_final_snapshot"></a> [skip\_final\_snapshot](#input\_skip\_final\_snapshot) | Determines whether a final snapshot of the cluster is created before Redshift deletes the cluster. If true, a final cluster snapshot is not created. If false , a final cluster snapshot is created before the cluster is deleted | `bool` | `true` | no |
+| <a name="input_snapshot_cluster_identifier"></a> [snapshot\_cluster\_identifier](#input\_snapshot\_cluster\_identifier) | The name of the cluster the source snapshot was created from | `string` | `null` | no |
+| <a name="input_snapshot_copy"></a> [snapshot\_copy](#input\_snapshot\_copy) | Configuration of automatic copy of snapshots from one region to another | `any` | `{}` | no |
+| <a name="input_snapshot_identifier"></a> [snapshot\_identifier](#input\_snapshot\_identifier) | The name of the snapshot from which to create the new cluster | `string` | `null` | no |
+| <a name="input_snapshot_schedule_definitions"></a> [snapshot\_schedule\_definitions](#input\_snapshot\_schedule\_definitions) | The definition of the snapshot schedule. The definition is made up of schedule expressions, for example `cron(30 12 *)` or `rate(12 hours)` | `list(string)` | `[]` | no |
+| <a name="input_snapshot_schedule_description"></a> [snapshot\_schedule\_description](#input\_snapshot\_schedule\_description) | The description of the snapshot schedule | `string` | `null` | no |
+| <a name="input_snapshot_schedule_force_destroy"></a> [snapshot\_schedule\_force\_destroy](#input\_snapshot\_schedule\_force\_destroy) | Whether to destroy all associated clusters with this snapshot schedule on deletion. Must be enabled and applied before attempting deletion | `bool` | `null` | no |
+| <a name="input_snapshot_schedule_identifier"></a> [snapshot\_schedule\_identifier](#input\_snapshot\_schedule\_identifier) | The snapshot schedule identifier | `string` | `null` | no |
+| <a name="input_subnet_group_description"></a> [subnet\_group\_description](#input\_subnet\_group\_description) | The description of the Redshift Subnet group. Defaults to `Managed by Terraform` | `string` | `null` | no |
+| <a name="input_subnet_group_name"></a> [subnet\_group\_name](#input\_subnet\_group\_name) | The name of the Redshift subnet group, existing or to be created | `string` | `null` | no |
+| <a name="input_subnet_group_tags"></a> [subnet\_group\_tags](#input\_subnet\_group\_tags) | Additional tags to add to the subnet group | `map(string)` | `{}` | no |
+| <a name="input_subnet_ids"></a> [subnet\_ids](#input\_subnet\_ids) | An array of VPC subnet IDs to use in the subnet group | `list(string)` | `[]` | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to add to all resources | `map(string)` | `{}` | no |
+| <a name="input_use_snapshot_identifier_prefix"></a> [use\_snapshot\_identifier\_prefix](#input\_use\_snapshot\_identifier\_prefix) | Determines whether the identifier (`snapshot_schedule_identifier`) is used as a prefix | `bool` | `true` | no |
+| <a name="input_vpc_security_group_ids"></a> [vpc\_security\_group\_ids](#input\_vpc\_security\_group\_ids) | A list of Virtual Private Cloud (VPC) security groups to be associated with the cluster | `list(string)` | `null` | no |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| <a name="output_redshift_cluster_arn"></a> [redshift\_cluster\_arn](#output\_redshift\_cluster\_arn) | The Redshift cluster ARN |
-| <a name="output_redshift_cluster_automated_snapshot_retention_period"></a> [redshift\_cluster\_automated\_snapshot\_retention\_period](#output\_redshift\_cluster\_automated\_snapshot\_retention\_period) | The backup retention period |
-| <a name="output_redshift_cluster_availability_zone"></a> [redshift\_cluster\_availability\_zone](#output\_redshift\_cluster\_availability\_zone) | The availability zone of the Cluster |
-| <a name="output_redshift_cluster_database_name"></a> [redshift\_cluster\_database\_name](#output\_redshift\_cluster\_database\_name) | The name of the default database in the Cluster |
-| <a name="output_redshift_cluster_encrypted"></a> [redshift\_cluster\_encrypted](#output\_redshift\_cluster\_encrypted) | Whether the data in the cluster is encrypted |
-| <a name="output_redshift_cluster_endpoint"></a> [redshift\_cluster\_endpoint](#output\_redshift\_cluster\_endpoint) | The connection endpoint |
-| <a name="output_redshift_cluster_hostname"></a> [redshift\_cluster\_hostname](#output\_redshift\_cluster\_hostname) | The hostname of the Redshift cluster |
-| <a name="output_redshift_cluster_id"></a> [redshift\_cluster\_id](#output\_redshift\_cluster\_id) | The Redshift cluster ID |
-| <a name="output_redshift_cluster_identifier"></a> [redshift\_cluster\_identifier](#output\_redshift\_cluster\_identifier) | The Redshift cluster identifier |
-| <a name="output_redshift_cluster_node_type"></a> [redshift\_cluster\_node\_type](#output\_redshift\_cluster\_node\_type) | The type of nodes in the cluster |
-| <a name="output_redshift_cluster_nodes"></a> [redshift\_cluster\_nodes](#output\_redshift\_cluster\_nodes) | Cluster nodes in the Redshift cluster |
-| <a name="output_redshift_cluster_parameter_group_name"></a> [redshift\_cluster\_parameter\_group\_name](#output\_redshift\_cluster\_parameter\_group\_name) | The name of the parameter group to be associated with this cluster |
-| <a name="output_redshift_cluster_port"></a> [redshift\_cluster\_port](#output\_redshift\_cluster\_port) | The port the cluster responds on |
-| <a name="output_redshift_cluster_preferred_maintenance_window"></a> [redshift\_cluster\_preferred\_maintenance\_window](#output\_redshift\_cluster\_preferred\_maintenance\_window) | The backup window |
-| <a name="output_redshift_cluster_public_key"></a> [redshift\_cluster\_public\_key](#output\_redshift\_cluster\_public\_key) | The public key for the cluster |
-| <a name="output_redshift_cluster_revision_number"></a> [redshift\_cluster\_revision\_number](#output\_redshift\_cluster\_revision\_number) | The specific revision number of the database in the cluster |
-| <a name="output_redshift_cluster_security_groups"></a> [redshift\_cluster\_security\_groups](#output\_redshift\_cluster\_security\_groups) | The security groups associated with the cluster |
-| <a name="output_redshift_cluster_subnet_group_name"></a> [redshift\_cluster\_subnet\_group\_name](#output\_redshift\_cluster\_subnet\_group\_name) | The name of a cluster subnet group to be associated with this cluster |
-| <a name="output_redshift_cluster_type"></a> [redshift\_cluster\_type](#output\_redshift\_cluster\_type) | The Redshift cluster type |
-| <a name="output_redshift_cluster_version"></a> [redshift\_cluster\_version](#output\_redshift\_cluster\_version) | The version of Redshift engine software |
-| <a name="output_redshift_cluster_vpc_security_group_ids"></a> [redshift\_cluster\_vpc\_security\_group\_ids](#output\_redshift\_cluster\_vpc\_security\_group\_ids) | The VPC security group ids associated with the cluster |
-| <a name="output_redshift_parameter_group_id"></a> [redshift\_parameter\_group\_id](#output\_redshift\_parameter\_group\_id) | The ID of Redshift parameter group created by this module |
-| <a name="output_redshift_subnet_group_id"></a> [redshift\_subnet\_group\_id](#output\_redshift\_subnet\_group\_id) | The ID of Redshift subnet group created by this module |
+| <a name="output_cluster_arn"></a> [cluster\_arn](#output\_cluster\_arn) | The Redshift cluster ARN |
+| <a name="output_cluster_automated_snapshot_retention_period"></a> [cluster\_automated\_snapshot\_retention\_period](#output\_cluster\_automated\_snapshot\_retention\_period) | The backup retention period |
+| <a name="output_cluster_availability_zone"></a> [cluster\_availability\_zone](#output\_cluster\_availability\_zone) | The availability zone of the Cluster |
+| <a name="output_cluster_database_name"></a> [cluster\_database\_name](#output\_cluster\_database\_name) | The name of the default database in the Cluster |
+| <a name="output_cluster_encrypted"></a> [cluster\_encrypted](#output\_cluster\_encrypted) | Whether the data in the cluster is encrypted |
+| <a name="output_cluster_endpoint"></a> [cluster\_endpoint](#output\_cluster\_endpoint) | The connection endpoint |
+| <a name="output_cluster_hostname"></a> [cluster\_hostname](#output\_cluster\_hostname) | The hostname of the Redshift cluster |
+| <a name="output_cluster_id"></a> [cluster\_id](#output\_cluster\_id) | The Redshift cluster ID |
+| <a name="output_cluster_identifier"></a> [cluster\_identifier](#output\_cluster\_identifier) | The Redshift cluster identifier |
+| <a name="output_cluster_node_type"></a> [cluster\_node\_type](#output\_cluster\_node\_type) | The type of nodes in the cluster |
+| <a name="output_cluster_nodes"></a> [cluster\_nodes](#output\_cluster\_nodes) | The nodes in the cluster. Each node is a map of the following attributes: `node_role`, `private_ip_address`, and `public_ip_address` |
+| <a name="output_cluster_parameter_group_name"></a> [cluster\_parameter\_group\_name](#output\_cluster\_parameter\_group\_name) | The name of the parameter group to be associated with this cluster |
+| <a name="output_cluster_port"></a> [cluster\_port](#output\_cluster\_port) | The port the cluster responds on |
+| <a name="output_cluster_preferred_maintenance_window"></a> [cluster\_preferred\_maintenance\_window](#output\_cluster\_preferred\_maintenance\_window) | The backup window |
+| <a name="output_cluster_public_key"></a> [cluster\_public\_key](#output\_cluster\_public\_key) | The public key for the cluster |
+| <a name="output_cluster_revision_number"></a> [cluster\_revision\_number](#output\_cluster\_revision\_number) | The specific revision number of the database in the cluster |
+| <a name="output_cluster_security_groups"></a> [cluster\_security\_groups](#output\_cluster\_security\_groups) | The security groups associated with the cluster |
+| <a name="output_cluster_subnet_group_name"></a> [cluster\_subnet\_group\_name](#output\_cluster\_subnet\_group\_name) | The name of a cluster subnet group to be associated with this cluster |
+| <a name="output_cluster_type"></a> [cluster\_type](#output\_cluster\_type) | The Redshift cluster type |
+| <a name="output_cluster_version"></a> [cluster\_version](#output\_cluster\_version) | The version of Redshift engine software |
+| <a name="output_cluster_vpc_security_group_ids"></a> [cluster\_vpc\_security\_group\_ids](#output\_cluster\_vpc\_security\_group\_ids) | The VPC security group ids associated with the cluster |
+| <a name="output_parameter_group_arn"></a> [parameter\_group\_arn](#output\_parameter\_group\_arn) | Amazon Resource Name (ARN) of the parameter group created |
+| <a name="output_parameter_group_id"></a> [parameter\_group\_id](#output\_parameter\_group\_id) | The name of the Redshift parameter group created |
+| <a name="output_scheduled_action_iam_role_arn"></a> [scheduled\_action\_iam\_role\_arn](#output\_scheduled\_action\_iam\_role\_arn) | Scheduled actions IAM role ARN |
+| <a name="output_scheduled_action_iam_role_name"></a> [scheduled\_action\_iam\_role\_name](#output\_scheduled\_action\_iam\_role\_name) | Scheduled actions IAM role name |
+| <a name="output_scheduled_action_iam_role_unique_id"></a> [scheduled\_action\_iam\_role\_unique\_id](#output\_scheduled\_action\_iam\_role\_unique\_id) | Stable and unique string identifying the scheduled action IAM role |
+| <a name="output_scheduled_actions"></a> [scheduled\_actions](#output\_scheduled\_actions) | A map of maps containing scheduled action details |
+| <a name="output_snapshot_schedule_arn"></a> [snapshot\_schedule\_arn](#output\_snapshot\_schedule\_arn) | Amazon Resource Name (ARN) of the Redshift Snapshot Schedule |
+| <a name="output_subnet_group_arn"></a> [subnet\_group\_arn](#output\_subnet\_group\_arn) | Amazon Resource Name (ARN) of the Redshift subnet group created |
+| <a name="output_subnet_group_id"></a> [subnet\_group\_id](#output\_subnet\_group\_id) | The ID of Redshift Subnet group created |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 
 ## Authors

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -19,24 +19,39 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.31 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 2.25 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.6 |
+| <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.0 |
 
 ## Providers
 
-No providers.
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.6 |
+| <a name="provider_aws.us_east_1"></a> [aws.us\_east\_1](#provider\_aws.us\_east\_1) | >= 4.6 |
+| <a name="provider_random"></a> [random](#provider\_random) | >= 3.0 |
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
+| <a name="module_default"></a> [default](#module\_default) | ../../ | n/a |
+| <a name="module_disabled"></a> [disabled](#module\_disabled) | ../../ | n/a |
 | <a name="module_redshift"></a> [redshift](#module\_redshift) | ../../ | n/a |
+| <a name="module_s3_logs"></a> [s3\_logs](#module\_s3\_logs) | terraform-aws-modules/s3-bucket/aws | ~> 3.0 |
 | <a name="module_sg"></a> [sg](#module\_sg) | terraform-aws-modules/security-group/aws//modules/redshift | ~> 4.0 |
 | <a name="module_vpc"></a> [vpc](#module\_vpc) | terraform-aws-modules/vpc/aws | ~> 3.0 |
 
 ## Resources
 
-No resources.
+| Name | Type |
+|------|------|
+| [aws_kms_key.redshift](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_key) | resource |
+| [aws_kms_key.redshift_us_east_1](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_key) | resource |
+| [aws_redshift_snapshot_copy_grant.useast1](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/redshift_snapshot_copy_grant) | resource |
+| [random_pet.s3_bucket](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/pet) | resource |
+| [aws_iam_policy_document.s3_redshift](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_redshift_service_account.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/redshift_service_account) | data source |
 
 ## Inputs
 
@@ -46,10 +61,34 @@ No inputs.
 
 | Name | Description |
 |------|-------------|
-| <a name="output_redshift_cluster_endpoint"></a> [redshift\_cluster\_endpoint](#output\_redshift\_cluster\_endpoint) | Redshift endpoint |
-| <a name="output_redshift_cluster_hostname"></a> [redshift\_cluster\_hostname](#output\_redshift\_cluster\_hostname) | Redshift hostname |
-| <a name="output_redshift_cluster_id"></a> [redshift\_cluster\_id](#output\_redshift\_cluster\_id) | The availability zone of the RDS instance |
-| <a name="output_redshift_cluster_port"></a> [redshift\_cluster\_port](#output\_redshift\_cluster\_port) | Redshift port |
-| <a name="output_security_group_id"></a> [security\_group\_id](#output\_security\_group\_id) | The ID of the security group |
-| <a name="output_vpc_id"></a> [vpc\_id](#output\_vpc\_id) | The ID of the VPC |
+| <a name="output_cluster_arn"></a> [cluster\_arn](#output\_cluster\_arn) | The Redshift cluster ARN |
+| <a name="output_cluster_automated_snapshot_retention_period"></a> [cluster\_automated\_snapshot\_retention\_period](#output\_cluster\_automated\_snapshot\_retention\_period) | The backup retention period |
+| <a name="output_cluster_availability_zone"></a> [cluster\_availability\_zone](#output\_cluster\_availability\_zone) | The availability zone of the Cluster |
+| <a name="output_cluster_database_name"></a> [cluster\_database\_name](#output\_cluster\_database\_name) | The name of the default database in the Cluster |
+| <a name="output_cluster_encrypted"></a> [cluster\_encrypted](#output\_cluster\_encrypted) | Whether the data in the cluster is encrypted |
+| <a name="output_cluster_endpoint"></a> [cluster\_endpoint](#output\_cluster\_endpoint) | The connection endpoint |
+| <a name="output_cluster_hostname"></a> [cluster\_hostname](#output\_cluster\_hostname) | The hostname of the Redshift cluster |
+| <a name="output_cluster_id"></a> [cluster\_id](#output\_cluster\_id) | The Redshift cluster ID |
+| <a name="output_cluster_identifier"></a> [cluster\_identifier](#output\_cluster\_identifier) | The Redshift cluster identifier |
+| <a name="output_cluster_node_type"></a> [cluster\_node\_type](#output\_cluster\_node\_type) | The type of nodes in the cluster |
+| <a name="output_cluster_nodes"></a> [cluster\_nodes](#output\_cluster\_nodes) | The nodes in the cluster. Each node is a map of the following attributes: `node_role`, `private_ip_address`, and `public_ip_address` |
+| <a name="output_cluster_parameter_group_name"></a> [cluster\_parameter\_group\_name](#output\_cluster\_parameter\_group\_name) | The name of the parameter group to be associated with this cluster |
+| <a name="output_cluster_port"></a> [cluster\_port](#output\_cluster\_port) | The port the cluster responds on |
+| <a name="output_cluster_preferred_maintenance_window"></a> [cluster\_preferred\_maintenance\_window](#output\_cluster\_preferred\_maintenance\_window) | The backup window |
+| <a name="output_cluster_public_key"></a> [cluster\_public\_key](#output\_cluster\_public\_key) | The public key for the cluster |
+| <a name="output_cluster_revision_number"></a> [cluster\_revision\_number](#output\_cluster\_revision\_number) | The specific revision number of the database in the cluster |
+| <a name="output_cluster_security_groups"></a> [cluster\_security\_groups](#output\_cluster\_security\_groups) | The security groups associated with the cluster |
+| <a name="output_cluster_subnet_group_name"></a> [cluster\_subnet\_group\_name](#output\_cluster\_subnet\_group\_name) | The name of a cluster subnet group to be associated with this cluster |
+| <a name="output_cluster_type"></a> [cluster\_type](#output\_cluster\_type) | The Redshift cluster type |
+| <a name="output_cluster_version"></a> [cluster\_version](#output\_cluster\_version) | The version of Redshift engine software |
+| <a name="output_cluster_vpc_security_group_ids"></a> [cluster\_vpc\_security\_group\_ids](#output\_cluster\_vpc\_security\_group\_ids) | The VPC security group ids associated with the cluster |
+| <a name="output_parameter_group_arn"></a> [parameter\_group\_arn](#output\_parameter\_group\_arn) | Amazon Resource Name (ARN) of the parameter group created |
+| <a name="output_parameter_group_id"></a> [parameter\_group\_id](#output\_parameter\_group\_id) | The name of the Redshift parameter group created |
+| <a name="output_scheduled_action_iam_role_arn"></a> [scheduled\_action\_iam\_role\_arn](#output\_scheduled\_action\_iam\_role\_arn) | Scheduled actions IAM role ARN |
+| <a name="output_scheduled_action_iam_role_name"></a> [scheduled\_action\_iam\_role\_name](#output\_scheduled\_action\_iam\_role\_name) | Scheduled actions IAM role name |
+| <a name="output_scheduled_action_iam_role_unique_id"></a> [scheduled\_action\_iam\_role\_unique\_id](#output\_scheduled\_action\_iam\_role\_unique\_id) | Stable and unique string identifying the scheduled action IAM role |
+| <a name="output_scheduled_actions"></a> [scheduled\_actions](#output\_scheduled\_actions) | A map of maps containing scheduled action details |
+| <a name="output_snapshot_schedule_arn"></a> [snapshot\_schedule\_arn](#output\_snapshot\_schedule\_arn) | Amazon Resource Name (ARN) of the Redshift Snapshot Schedule |
+| <a name="output_subnet_group_arn"></a> [subnet\_group\_arn](#output\_subnet\_group\_arn) | Amazon Resource Name (ARN) of the Redshift subnet group created |
+| <a name="output_subnet_group_id"></a> [subnet\_group\_id](#output\_subnet\_group\_id) | The ID of Redshift Subnet group created |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -1,55 +1,286 @@
 provider "aws" {
-  region = "eu-west-1"
+  region = local.region
 }
 
-######
-# VPC
-######
+provider "aws" {
+  alias  = "us_east_1"
+  region = "us-east-1"
+}
+
+locals {
+  name   = "ex-redshift"
+  region = "eu-west-1"
+
+  s3_prefix = "redshift/${local.name}/"
+
+  tags = {
+    Owner       = "user"
+    Environment = "dev"
+  }
+}
+
+################################################################################
+# Supporting Resources
+################################################################################
+
 module "vpc" {
   source  = "terraform-aws-modules/vpc/aws"
   version = "~> 3.0"
 
-  name = "demo-vpc"
+  name = local.name
+  cidr = "10.99.0.0/18"
 
-  cidr = "10.10.0.0/16"
+  azs              = ["${local.region}a", "${local.region}b", "${local.region}c"]
+  redshift_subnets = ["10.99.0.0/24", "10.99.1.0/24", "10.99.2.0/24"]
 
-  azs              = ["eu-west-1a", "eu-west-1b", "eu-west-1c"]
-  redshift_subnets = ["10.10.41.0/24", "10.10.42.0/24", "10.10.43.0/24"]
+  # Disabling here since module creates one by default, named the same which conflicts
+  create_redshift_subnet_group = false
+
+  tags = local.tags
 }
 
-###########################
-# Security group
-###########################
 module "sg" {
   source  = "terraform-aws-modules/security-group/aws//modules/redshift"
   version = "~> 4.0"
 
-  name   = "demo-redshift"
-  vpc_id = module.vpc.vpc_id
+  name        = local.name
+  description = "A security group"
+  vpc_id      = module.vpc.vpc_id
 
   # Allow ingress rules to be accessed only within current VPC
   ingress_cidr_blocks = [module.vpc.vpc_cidr_block]
 
   # Allow all rules for all protocols
   egress_rules = ["all-all"]
+
+  tags = local.tags
 }
 
-###########
-# Redshift
-###########
+resource "aws_kms_key" "redshift" {
+  description             = "Customer managed key for encrypting Redshift cluster"
+  deletion_window_in_days = 7
+  enable_key_rotation     = true
+
+  tags = local.tags
+}
+
+resource "aws_kms_key" "redshift_us_east_1" {
+  provider = aws.us_east_1
+
+  description             = "Customer managed key for encrypting Redshift snapshot cross-region"
+  deletion_window_in_days = 7
+  enable_key_rotation     = true
+
+  tags = local.tags
+}
+
+data "aws_redshift_service_account" "this" {}
+
+data "aws_iam_policy_document" "s3_redshift" {
+  statement {
+    sid       = "RedshiftAcl"
+    actions   = ["s3:GetBucketAcl"]
+    resources = [module.s3_logs.s3_bucket_arn]
+
+    principals {
+      type        = "AWS"
+      identifiers = [data.aws_redshift_service_account.this.arn]
+    }
+  }
+
+  statement {
+    sid       = "RedshiftWrite"
+    actions   = ["s3:PutObject"]
+    resources = ["${module.s3_logs.s3_bucket_arn}/${local.s3_prefix}*"]
+    condition {
+      test     = "StringEquals"
+      values   = ["bucket-owner-full-control"]
+      variable = "s3:x-amz-acl"
+    }
+
+    principals {
+      type        = "AWS"
+      identifiers = [data.aws_redshift_service_account.this.arn]
+    }
+  }
+}
+
+resource "random_pet" "s3_bucket" {
+  length = 2
+}
+
+module "s3_logs" {
+  source  = "terraform-aws-modules/s3-bucket/aws"
+  version = "~> 3.0"
+
+  bucket = "${local.name}-${random_pet.s3_bucket.id}"
+  acl    = "log-delivery-write"
+
+  attach_policy = true
+  policy        = data.aws_iam_policy_document.s3_redshift.json
+
+  attach_deny_insecure_transport_policy = true
+  force_destroy                         = true
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+
+  tags = local.tags
+}
+
+################################################################################
+# Disabled
+################################################################################
+
+module "disabled" {
+  source = "../../"
+
+  create = false
+
+  cluster_identifier = local.name
+}
+
+################################################################################
+# Default
+################################################################################
+
+module "default" {
+  source = "../../"
+
+  cluster_identifier = local.name
+
+  vpc_security_group_ids = [module.sg.security_group_id]
+  subnet_ids             = module.vpc.redshift_subnets
+
+  tags = local.tags
+}
+
+################################################################################
+# Complete
+################################################################################
+
+resource "aws_redshift_snapshot_copy_grant" "useast1" {
+  # Grants are declared outside of module because they are generally performed
+  # in the destination region and we do not embed multiple providers in the root module
+  provider = aws.us_east_1
+
+  snapshot_copy_grant_name = "${local.name}-us-east-1"
+  kms_key_id               = aws_kms_key.redshift_us_east_1.arn
+
+  tags = local.tags
+}
+
 module "redshift" {
   source = "../../"
 
-  cluster_identifier      = "my-cluster"
-  cluster_node_type       = "dc1.large"
-  cluster_number_of_nodes = 1
+  cluster_identifier    = "${local.name}-complete"
+  allow_version_upgrade = true
+  node_type             = "ds2.xlarge"
+  number_of_nodes       = 3
 
-  cluster_database_name   = "mydb"
-  cluster_master_username = "mydbuser"
-  cluster_master_password = "MySecretPassw0rd"
+  database_name   = "mydb"
+  master_username = "mydbuser"
+  master_password = "MySecretPassw0rd1!" # Do better!
 
-  subnets                = module.vpc.redshift_subnets
+  encrypted   = true
+  kms_key_arn = aws_kms_key.redshift.arn
+
+  enhanced_vpc_routing   = true
   vpc_security_group_ids = [module.sg.security_group_id]
+  subnet_ids             = module.vpc.redshift_subnets
 
-  #  redshift_subnet_group_name = module.vpc.redshift_subnet_group
+  snapshot_copy = {
+    useast1 = {
+      destination_region = "us-east-1"
+      grant_name         = aws_redshift_snapshot_copy_grant.useast1.snapshot_copy_grant_name
+    }
+  }
+
+  logging = {
+    enable        = true
+    bucket_name   = module.s3_logs.s3_bucket_id
+    s3_key_prefix = local.s3_prefix
+  }
+
+  # Parameter group
+  parameter_group_name        = "${local.name}-custom"
+  parameter_group_description = "Custom parameter group for ${local.name} cluster"
+  parameter_group_parameters = {
+    wlm_json_configuration = {
+      name = "wlm_json_configuration"
+      value = jsonencode([
+        {
+          query_concurrency = 15
+        }
+      ])
+    }
+    require_ssl = {
+      name  = "require_ssl"
+      value = true
+    }
+    use_fips_ssl = {
+      name  = "use_fips_ssl"
+      value = false
+    }
+    enable_user_activity_logging = {
+      name  = "enable_user_activity_logging"
+      value = true
+    }
+    max_concurrency_scaling_clusters = {
+      name  = "max_concurrency_scaling_clusters"
+      value = 3
+    }
+    enable_case_sensitive_identifier = {
+      name  = "enable_case_sensitive_identifier"
+      value = true
+    }
+  }
+  parameter_group_tags = {
+    Additional = "CustomParameterGroup"
+  }
+
+  # Subnet group
+  subnet_group_name        = "${local.name}-custom"
+  subnet_group_description = "Custom subnet group for ${local.name} cluster"
+  subnet_group_tags = {
+    Additional = "CustomSubnetGroup"
+  }
+
+  # Snapshot schedule
+  create_snapshot_schedule        = true
+  snapshot_schedule_identifier    = local.name
+  use_snapshot_identifier_prefix  = true
+  snapshot_schedule_description   = "Example snapshot schedule"
+  snapshot_schedule_definitions   = ["rate(12 hours)"]
+  snapshot_schedule_force_destroy = true
+
+  # Scheduled actions
+  create_scheduled_action_iam_role = true
+  scheduled_actions = {
+    pause = {
+      name          = "${local.name}-pause"
+      description   = "Pause cluster every night"
+      schedule      = "cron(0 22 * * ? *)"
+      pause_cluster = true
+    }
+    resize = {
+      name        = "${local.name}-resize"
+      description = "Resize cluster (demo only)"
+      schedule    = "cron(00 13 * * ? *)"
+      resize_cluster = {
+        node_type       = "ds2.xlarge"
+        number_of_nodes = 5
+      }
+    }
+    resume = {
+      name           = "${local.name}-resume"
+      description    = "Resume cluster every morning"
+      schedule       = "cron(0 12 * * ? *)"
+      resume_cluster = true
+    }
+  }
+
+  tags = local.tags
 }

--- a/examples/complete/outputs.tf
+++ b/examples/complete/outputs.tf
@@ -1,29 +1,170 @@
-output "vpc_id" {
-  description = "The ID of the VPC"
-  value       = module.vpc.vpc_id
+################################################################################
+# Cluster
+################################################################################
+
+output "cluster_arn" {
+  description = "The Redshift cluster ARN"
+  value       = module.redshift.cluster_arn
 }
 
-output "security_group_id" {
-  description = "The ID of the security group"
-  value       = module.sg.security_group_id
+output "cluster_id" {
+  description = "The Redshift cluster ID"
+  value       = module.redshift.cluster_id
 }
 
-output "redshift_cluster_id" {
-  description = "The availability zone of the RDS instance"
-  value       = module.redshift.redshift_cluster_id
+output "cluster_identifier" {
+  description = "The Redshift cluster identifier"
+  value       = module.redshift.cluster_identifier
 }
 
-output "redshift_cluster_endpoint" {
-  description = "Redshift endpoint"
-  value       = module.redshift.redshift_cluster_endpoint
+output "cluster_type" {
+  description = "The Redshift cluster type"
+  value       = module.redshift.cluster_type
 }
 
-output "redshift_cluster_hostname" {
-  description = "Redshift hostname"
-  value       = module.redshift.redshift_cluster_hostname
+output "cluster_node_type" {
+  description = "The type of nodes in the cluster"
+  value       = module.redshift.cluster_node_type
 }
 
-output "redshift_cluster_port" {
-  description = "Redshift port"
-  value       = module.redshift.redshift_cluster_port
+output "cluster_database_name" {
+  description = "The name of the default database in the Cluster"
+  value       = module.redshift.cluster_database_name
+}
+
+output "cluster_availability_zone" {
+  description = "The availability zone of the Cluster"
+  value       = module.redshift.cluster_availability_zone
+}
+
+output "cluster_automated_snapshot_retention_period" {
+  description = "The backup retention period"
+  value       = module.redshift.cluster_automated_snapshot_retention_period
+}
+
+output "cluster_preferred_maintenance_window" {
+  description = "The backup window"
+  value       = module.redshift.cluster_preferred_maintenance_window
+}
+
+output "cluster_endpoint" {
+  description = "The connection endpoint"
+  value       = module.redshift.cluster_endpoint
+}
+
+output "cluster_hostname" {
+  description = "The hostname of the Redshift cluster"
+  value       = module.redshift.cluster_hostname
+}
+
+output "cluster_encrypted" {
+  description = "Whether the data in the cluster is encrypted"
+  value       = module.redshift.cluster_encrypted
+}
+
+output "cluster_security_groups" {
+  description = "The security groups associated with the cluster"
+  value       = module.redshift.cluster_security_groups
+}
+
+output "cluster_vpc_security_group_ids" {
+  description = "The VPC security group ids associated with the cluster"
+  value       = module.redshift.cluster_vpc_security_group_ids
+}
+
+output "cluster_port" {
+  description = "The port the cluster responds on"
+  value       = module.redshift.cluster_port
+}
+
+output "cluster_version" {
+  description = "The version of Redshift engine software"
+  value       = module.redshift.cluster_version
+}
+
+output "cluster_parameter_group_name" {
+  description = "The name of the parameter group to be associated with this cluster"
+  value       = module.redshift.cluster_parameter_group_name
+}
+
+output "cluster_subnet_group_name" {
+  description = "The name of a cluster subnet group to be associated with this cluster"
+  value       = module.redshift.cluster_subnet_group_name
+}
+
+output "cluster_public_key" {
+  description = "The public key for the cluster"
+  value       = module.redshift.cluster_public_key
+}
+
+output "cluster_revision_number" {
+  description = "The specific revision number of the database in the cluster"
+  value       = module.redshift.cluster_revision_number
+}
+
+output "cluster_nodes" {
+  description = "The nodes in the cluster. Each node is a map of the following attributes: `node_role`, `private_ip_address`, and `public_ip_address`"
+  value       = module.redshift.cluster_nodes
+}
+
+################################################################################
+# Paramter Group
+################################################################################
+
+output "parameter_group_arn" {
+  description = "Amazon Resource Name (ARN) of the parameter group created"
+  value       = module.redshift.parameter_group_arn
+}
+
+output "parameter_group_id" {
+  description = "The name of the Redshift parameter group created"
+  value       = module.redshift.parameter_group_id
+}
+
+################################################################################
+# Paramter Group
+################################################################################
+
+output "subnet_group_arn" {
+  description = "Amazon Resource Name (ARN) of the Redshift subnet group created"
+  value       = module.redshift.subnet_group_arn
+}
+
+output "subnet_group_id" {
+  description = "The ID of Redshift Subnet group created"
+  value       = module.redshift.subnet_group_id
+}
+
+################################################################################
+# Snapshot Schedule
+################################################################################
+
+output "snapshot_schedule_arn" {
+  description = "Amazon Resource Name (ARN) of the Redshift Snapshot Schedule"
+  value       = module.redshift.snapshot_schedule_arn
+}
+
+################################################################################
+# Scheduled Action
+################################################################################
+
+output "scheduled_actions" {
+  description = "A map of maps containing scheduled action details"
+  value       = module.redshift.scheduled_actions
+}
+
+
+output "scheduled_action_iam_role_name" {
+  description = "Scheduled actions IAM role name"
+  value       = module.redshift.scheduled_action_iam_role_name
+}
+
+output "scheduled_action_iam_role_arn" {
+  description = "Scheduled actions IAM role ARN"
+  value       = module.redshift.scheduled_action_iam_role_arn
+}
+
+output "scheduled_action_iam_role_unique_id" {
+  description = "Stable and unique string identifying the scheduled action IAM role"
+  value       = module.redshift.scheduled_action_iam_role_unique_id
 }

--- a/examples/complete/versions.tf
+++ b/examples/complete/versions.tf
@@ -1,7 +1,14 @@
 terraform {
-  required_version = ">= 0.12.31"
+  required_version = ">= 0.13.1"
 
   required_providers {
-    aws = ">= 2.25"
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 4.6"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = ">= 3.0"
+    }
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -1,74 +1,68 @@
 locals {
-  # if passed a value for redshift_subnet_group_name, we'll use that instead of creating a subnet group
-  redshift_subnet_group_name = coalesce(
-    var.redshift_subnet_group_name,
-    element(concat(aws_redshift_subnet_group.this.*.name, [""]), 0),
-  )
-
-  # if we were passed a value for parameter_group_name, we'll use that instead of creating a parameter group name
-  parameter_group_name = coalesce(
-    var.parameter_group_name,
-    element(concat(aws_redshift_parameter_group.this.*.id, [""]), 0),
-  )
+  subnet_group_name    = var.create && var.create_subnet_group ? aws_redshift_subnet_group.this[0].name : var.subnet_group_name
+  parameter_group_name = var.create && var.create_parameter_group ? aws_redshift_parameter_group.this[0].id : var.parameter_group_name
 }
 
 resource "aws_redshift_cluster" "this" {
-  cluster_identifier = var.cluster_identifier
-  cluster_version    = var.cluster_version
-  node_type          = var.cluster_node_type
-  number_of_nodes    = var.cluster_number_of_nodes
-  cluster_type       = var.cluster_number_of_nodes > 1 ? "multi-node" : "single-node"
-  database_name      = var.cluster_database_name
-  master_username    = var.cluster_master_username
-  master_password    = var.cluster_master_password
+  count = var.create ? 1 : 0
 
-  port = var.cluster_port
-
-  vpc_security_group_ids = var.vpc_security_group_ids
-
-  cluster_subnet_group_name    = local.redshift_subnet_group_name
+  cluster_identifier           = var.cluster_identifier
+  cluster_version              = var.cluster_version
+  allow_version_upgrade        = var.allow_version_upgrade
+  cluster_type                 = var.number_of_nodes > 1 ? "multi-node" : "single-node"
+  cluster_subnet_group_name    = local.subnet_group_name
   cluster_parameter_group_name = local.parameter_group_name
 
-  publicly_accessible = var.publicly_accessible
-  elastic_ip          = var.elastic_ip
+  node_type       = var.node_type
+  number_of_nodes = var.number_of_nodes
+  port            = var.port
 
-  # Restore from snapshot
-  snapshot_identifier         = var.snapshot_identifier
-  snapshot_cluster_identifier = var.snapshot_cluster_identifier
-  owner_account               = var.owner_account
+  database_name   = var.database_name
+  master_username = var.snapshot_identifier != null ? null : var.master_username
+  master_password = var.snapshot_identifier != null ? null : var.master_password
 
-  # Snapshots and backups
+  iam_roles  = var.iam_roles
+  encrypted  = var.encrypted
+  kms_key_id = var.kms_key_arn
+
+  enhanced_vpc_routing                 = var.enhanced_vpc_routing
+  cluster_security_groups              = var.cluster_security_groups
+  vpc_security_group_ids               = var.vpc_security_group_ids
+  publicly_accessible                  = var.publicly_accessible
+  elastic_ip                           = var.elastic_ip
+  availability_zone                    = var.availability_zone
+  availability_zone_relocation_enabled = var.availability_zone_relocation_enabled
+
+  owner_account                       = var.owner_account
+  snapshot_identifier                 = var.snapshot_identifier
+  snapshot_cluster_identifier         = var.snapshot_cluster_identifier
   final_snapshot_identifier           = var.skip_final_snapshot ? null : var.final_snapshot_identifier
   skip_final_snapshot                 = var.skip_final_snapshot
   automated_snapshot_retention_period = var.automated_snapshot_retention_period
   preferred_maintenance_window        = var.preferred_maintenance_window
-  allow_version_upgrade               = var.allow_version_upgrade
 
-  # Snapshots copy to another region
   dynamic "snapshot_copy" {
-    for_each = compact([var.snapshot_copy_destination_region])
+    for_each = var.snapshot_copy
     content {
-      destination_region = var.snapshot_copy_destination_region
-      retention_period   = var.automated_snapshot_retention_period
-      grant_name         = var.snapshot_copy_grant_name
+      destination_region = snapshot_copy.value.destination_region
+      retention_period   = lookup(snapshot_copy.value, "retention_period", null)
+      grant_name         = lookup(snapshot_copy.value, "grant_name", null)
     }
   }
 
-  # IAM Roles
-  iam_roles = var.cluster_iam_roles
+  dynamic "logging" {
+    for_each = can(var.logging.enable) ? [var.logging] : []
+    content {
+      enable        = logging.value.enable
+      bucket_name   = logging.value.bucket_name
+      s3_key_prefix = lookup(logging.value, "s3_key_prefix", null)
+    }
+  }
 
-  # Encryption
-  encrypted  = var.encrypted
-  kms_key_id = var.kms_key_id
-
-  # Enhanced VPC routing
-  enhanced_vpc_routing = var.enhanced_vpc_routing
-
-  # Logging
-  logging {
-    enable        = var.enable_logging
-    bucket_name   = var.logging_bucket_name
-    s3_key_prefix = var.logging_s3_key_prefix
+  timeouts {
+    create = lookup(var.cluster_timeouts, "create", null)
+    update = lookup(var.cluster_timeouts, "update", null)
+    delete = lookup(var.cluster_timeouts, "delete", null)
   }
 
   tags = var.tags
@@ -78,55 +72,151 @@ resource "aws_redshift_cluster" "this" {
   }
 }
 
+################################################################################
+# Paramter Group
+################################################################################
+
 resource "aws_redshift_parameter_group" "this" {
-  # if we were passed a value for parameter_group_name, don't bother creating a parameter group
-  count  = length(var.parameter_group_name) > 0 ? 0 : 1
-  name   = "${var.cluster_identifier}-${replace(var.cluster_parameter_group, ".", "-")}-custom-params"
-  family = var.cluster_parameter_group
+  count = var.create && var.create_parameter_group ? 1 : 0
 
-  parameter {
-    name  = "wlm_json_configuration"
-    value = var.wlm_json_configuration
+  name        = coalesce(var.parameter_group_name, replace(var.cluster_identifier, ".", "-"))
+  description = var.parameter_group_description
+  family      = var.parameter_group_family
+
+  dynamic "parameter" {
+    for_each = var.parameter_group_parameters
+    content {
+      name  = parameter.value.name
+      value = parameter.value.value
+    }
   }
 
-  parameter {
-    # ref: https://docs.aws.amazon.com/redshift/latest/mgmt/connecting-ssl-support.html
-    name  = "require_ssl"
-    value = var.require_ssl
-  }
+  tags = merge(var.tags, var.parameter_group_tags)
+}
 
-  parameter {
-    name  = "use_fips_ssl"
-    value = var.use_fips_ssl
-  }
+################################################################################
+# Subnet Group
+################################################################################
 
-  parameter {
-    # ref: https://docs.aws.amazon.com/redshift/latest/mgmt/db-auditing.html
-    name  = "enable_user_activity_logging"
-    value = var.enable_user_activity_logging
-  }
+resource "aws_redshift_subnet_group" "this" {
+  count = var.create && var.create_subnet_group ? 1 : 0
 
-  parameter {
-    # ref: https://docs.aws.amazon.com/redshift/latest/dg/concurrency-scaling.html
-    name  = "max_concurrency_scaling_clusters"
-    value = var.max_concurrency_scaling_clusters
-  }
+  name        = coalesce(var.subnet_group_name, var.cluster_identifier)
+  description = var.subnet_group_description
+  subnet_ids  = var.subnet_ids
 
-  parameter {
-    # ref: https://docs.aws.amazon.com/redshift/latest/dg/r_enable_case_sensitive_identifier.html
-    name  = "enable_case_sensitive_identifier"
-    value = var.enable_case_sensitive_identifier
-  }
+  tags = merge(var.tags, var.subnet_group_tags)
+}
+
+################################################################################
+# Snapshot Schedule
+################################################################################
+
+resource "aws_redshift_snapshot_schedule" "this" {
+  count = var.create && var.create_snapshot_schedule ? 1 : 0
+
+  identifier        = var.use_snapshot_identifier_prefix ? null : var.snapshot_schedule_identifier
+  identifier_prefix = var.use_snapshot_identifier_prefix ? "${var.snapshot_schedule_identifier}-" : null
+  description       = var.snapshot_schedule_description
+  definitions       = var.snapshot_schedule_definitions
+  force_destroy     = var.snapshot_schedule_force_destroy
 
   tags = var.tags
 }
 
-resource "aws_redshift_subnet_group" "this" {
-  count = var.redshift_subnet_group_name == "" ? 1 : 0
+resource "aws_redshift_snapshot_schedule_association" "this" {
+  count = var.create && var.create_snapshot_schedule ? 1 : 0
 
-  name        = var.cluster_identifier
-  description = "Redshift subnet group of ${var.cluster_identifier}"
-  subnet_ids  = var.subnets
+  cluster_identifier  = aws_redshift_cluster.this[0].id
+  schedule_identifier = aws_redshift_snapshot_schedule.this[0].id
+}
 
-  tags = var.tags
+################################################################################
+# Scheduled Action
+################################################################################
+
+locals {
+  iam_role_name = coalesce(var.iam_role_name, "${var.cluster_identifier}-scheduled-action")
+}
+
+resource "aws_redshift_scheduled_action" "this" {
+  for_each = { for k, v in var.scheduled_actions : k => v if var.create }
+
+  name        = each.value.name
+  description = lookup(each.value, "description", null)
+  enable      = lookup(each.value, "enable", null)
+  start_time  = lookup(each.value, "start_time", null)
+  end_time    = lookup(each.value, "end_time", null)
+  schedule    = each.value.schedule
+  iam_role    = try(aws_iam_role.scheduled_action[0].arn, each.value.iam_role)
+
+  target_action {
+    dynamic "pause_cluster" {
+      for_each = can(each.value.pause_cluster) ? [each.value.pause_cluster] : []
+      content {
+        cluster_identifier = aws_redshift_cluster.this[0].id
+      }
+    }
+
+    dynamic "resize_cluster" {
+      for_each = can(each.value.resize_cluster) ? [each.value.resize_cluster] : []
+      content {
+        cluster_identifier = aws_redshift_cluster.this[0].id
+        classic            = lookup(resize_cluster.value, "classic", null)
+        cluster_type       = lookup(resize_cluster.value, "cluster_type", null)
+        node_type          = lookup(resize_cluster.value, "node_type", null)
+        number_of_nodes    = lookup(resize_cluster.value, "number_of_nodes", null)
+      }
+    }
+
+    dynamic "resume_cluster" {
+      for_each = can(each.value.resume_cluster) ? [each.value.resume_cluster] : []
+      content {
+        cluster_identifier = aws_redshift_cluster.this[0].id
+      }
+    }
+  }
+}
+
+resource "aws_iam_role" "scheduled_action" {
+  count = var.create && var.create_scheduled_action_iam_role ? 1 : 0
+
+  name        = var.iam_role_use_name_prefix ? null : local.iam_role_name
+  name_prefix = var.iam_role_use_name_prefix ? "${local.iam_role_name}-" : null
+  path        = var.iam_role_path
+  description = var.iam_role_description
+
+  permissions_boundary  = var.iam_role_permissions_boundary
+  force_detach_policies = true
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [{
+      Sid    = "ScheduleActionAssume"
+      Effect = "Allow"
+      Action = "sts:AssumeRole"
+      Principal = {
+        Service = ["scheduler.redshift.amazonaws.com"]
+      }
+    }]
+  })
+
+  inline_policy {
+    name = var.iam_role_name
+    policy = jsonencode({
+      Version = "2012-10-17",
+      Statement = [{
+        Sid    = "ModifyCluster"
+        Effect = "Allow"
+        Action = [
+          "redshift:PauseCluster",
+          "redshift:ResumeCluster",
+          "redshift:ResizeCluster"
+        ],
+        Resource = aws_redshift_cluster.this[0].arn
+      }]
+    })
+  }
+
+  tags = merge(var.tags, var.iam_role_tags)
 }

--- a/main.tf
+++ b/main.tf
@@ -73,7 +73,7 @@ resource "aws_redshift_cluster" "this" {
 }
 
 ################################################################################
-# Paramter Group
+# Parameter Group
 ################################################################################
 
 resource "aws_redshift_parameter_group" "this" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,118 +1,173 @@
-output "redshift_cluster_arn" {
+################################################################################
+# Cluster
+################################################################################
+
+output "cluster_arn" {
   description = "The Redshift cluster ARN"
-  value       = aws_redshift_cluster.this.arn
+  value       = try(aws_redshift_cluster.this[0].arn, "")
 }
 
-output "redshift_cluster_id" {
+output "cluster_id" {
   description = "The Redshift cluster ID"
-  value       = aws_redshift_cluster.this.id
+  value       = try(aws_redshift_cluster.this[0].id, "")
 }
 
-output "redshift_cluster_identifier" {
+output "cluster_identifier" {
   description = "The Redshift cluster identifier"
-  value       = aws_redshift_cluster.this.cluster_identifier
+  value       = try(aws_redshift_cluster.this[0].cluster_identifier, "")
 }
 
-output "redshift_cluster_type" {
+output "cluster_type" {
   description = "The Redshift cluster type"
-  value       = aws_redshift_cluster.this.cluster_type
+  value       = try(aws_redshift_cluster.this[0].cluster_type, "")
 }
 
-output "redshift_cluster_node_type" {
+output "cluster_node_type" {
   description = "The type of nodes in the cluster"
-  value       = aws_redshift_cluster.this.node_type
+  value       = try(aws_redshift_cluster.this[0].node_type, "")
 }
 
-output "redshift_cluster_database_name" {
+output "cluster_database_name" {
   description = "The name of the default database in the Cluster"
-  value       = aws_redshift_cluster.this.database_name
+  value       = try(aws_redshift_cluster.this[0].database_name, "")
 }
 
-output "redshift_cluster_availability_zone" {
+output "cluster_availability_zone" {
   description = "The availability zone of the Cluster"
-  value       = aws_redshift_cluster.this.availability_zone
+  value       = try(aws_redshift_cluster.this[0].availability_zone, "")
 }
 
-output "redshift_cluster_automated_snapshot_retention_period" {
+output "cluster_automated_snapshot_retention_period" {
   description = "The backup retention period"
-  value       = aws_redshift_cluster.this.automated_snapshot_retention_period
+  value       = try(aws_redshift_cluster.this[0].automated_snapshot_retention_period, "")
 }
 
-output "redshift_cluster_preferred_maintenance_window" {
+output "cluster_preferred_maintenance_window" {
   description = "The backup window"
-  value       = aws_redshift_cluster.this.preferred_maintenance_window
+  value       = try(aws_redshift_cluster.this[0].preferred_maintenance_window, "")
 }
 
-output "redshift_cluster_endpoint" {
+output "cluster_endpoint" {
   description = "The connection endpoint"
-  value       = aws_redshift_cluster.this.endpoint
+  value       = try(aws_redshift_cluster.this[0].endpoint, "")
 }
 
-output "redshift_cluster_hostname" {
+output "cluster_hostname" {
   description = "The hostname of the Redshift cluster"
   value = replace(
-    aws_redshift_cluster.this.endpoint,
-    format(":%s", aws_redshift_cluster.this.port),
+    try(aws_redshift_cluster.this[0].endpoint, ""),
+    format(":%s", try(aws_redshift_cluster.this[0].port, "")),
     "",
   )
 }
 
-output "redshift_cluster_encrypted" {
+output "cluster_encrypted" {
   description = "Whether the data in the cluster is encrypted"
-  value       = aws_redshift_cluster.this.encrypted
+  value       = try(aws_redshift_cluster.this[0].encrypted, "")
 }
 
-output "redshift_cluster_security_groups" {
+output "cluster_security_groups" {
   description = "The security groups associated with the cluster"
-  value       = aws_redshift_cluster.this.cluster_security_groups
+  value       = try(aws_redshift_cluster.this[0].cluster_security_groups, [])
 }
 
-output "redshift_cluster_vpc_security_group_ids" {
+output "cluster_vpc_security_group_ids" {
   description = "The VPC security group ids associated with the cluster"
-  value       = aws_redshift_cluster.this.vpc_security_group_ids
+  value       = try(aws_redshift_cluster.this[0].vpc_security_group_ids, [])
 }
 
-output "redshift_cluster_port" {
+output "cluster_port" {
   description = "The port the cluster responds on"
-  value       = aws_redshift_cluster.this.port
+  value       = try(aws_redshift_cluster.this[0].port, "")
 }
 
-output "redshift_cluster_version" {
+output "cluster_version" {
   description = "The version of Redshift engine software"
-  value       = aws_redshift_cluster.this.cluster_version
+  value       = try(aws_redshift_cluster.this[0].cluster_version, "")
 }
 
-output "redshift_cluster_parameter_group_name" {
+output "cluster_parameter_group_name" {
   description = "The name of the parameter group to be associated with this cluster"
-  value       = aws_redshift_cluster.this.cluster_parameter_group_name
+  value       = try(aws_redshift_cluster.this[0].cluster_parameter_group_name, "")
 }
 
-output "redshift_cluster_subnet_group_name" {
+output "cluster_subnet_group_name" {
   description = "The name of a cluster subnet group to be associated with this cluster"
-  value       = aws_redshift_cluster.this.cluster_subnet_group_name
+  value       = try(aws_redshift_cluster.this[0].cluster_subnet_group_name, "")
 }
 
-output "redshift_cluster_public_key" {
+output "cluster_public_key" {
   description = "The public key for the cluster"
-  value       = aws_redshift_cluster.this.cluster_public_key
+  value       = try(aws_redshift_cluster.this[0].cluster_public_key, "")
 }
 
-output "redshift_cluster_revision_number" {
+output "cluster_revision_number" {
   description = "The specific revision number of the database in the cluster"
-  value       = aws_redshift_cluster.this.cluster_revision_number
+  value       = try(aws_redshift_cluster.this[0].cluster_revision_number, "")
 }
 
-output "redshift_subnet_group_id" {
-  description = "The ID of Redshift subnet group created by this module"
-  value       = element(concat(aws_redshift_subnet_group.this.*.id, [""]), 0)
+output "cluster_nodes" {
+  description = "The nodes in the cluster. Each node is a map of the following attributes: `node_role`, `private_ip_address`, and `public_ip_address`"
+  value       = try(aws_redshift_cluster.this[0].cluster_nodes, {})
 }
 
-output "redshift_parameter_group_id" {
-  description = "The ID of Redshift parameter group created by this module"
-  value       = element(concat(aws_redshift_parameter_group.this.*.id, [""]), 0)
+################################################################################
+# Paramter Group
+################################################################################
+
+output "parameter_group_arn" {
+  description = "Amazon Resource Name (ARN) of the parameter group created"
+  value       = try(aws_redshift_parameter_group.this[0].arn, "")
 }
 
-output "redshift_cluster_nodes" {
-  description = "Cluster nodes in the Redshift cluster"
-  value       = aws_redshift_cluster.this.cluster_nodes
+output "parameter_group_id" {
+  description = "The name of the Redshift parameter group created"
+  value       = try(aws_redshift_parameter_group.this[0].id, "")
+}
+
+################################################################################
+# Paramter Group
+################################################################################
+
+output "subnet_group_arn" {
+  description = "Amazon Resource Name (ARN) of the Redshift subnet group created"
+  value       = try(aws_redshift_subnet_group.this[0].arn, "")
+}
+
+output "subnet_group_id" {
+  description = "The ID of Redshift Subnet group created"
+  value       = try(aws_redshift_subnet_group.this[0].id, "")
+}
+
+################################################################################
+# Snapshot Schedule
+################################################################################
+
+output "snapshot_schedule_arn" {
+  description = "Amazon Resource Name (ARN) of the Redshift Snapshot Schedule"
+  value       = try(aws_redshift_snapshot_schedule.this[0].arn, "")
+}
+
+################################################################################
+# Scheduled Action
+################################################################################
+
+output "scheduled_actions" {
+  description = "A map of maps containing scheduled action details"
+  value       = aws_redshift_scheduled_action.this
+}
+
+output "scheduled_action_iam_role_name" {
+  description = "Scheduled actions IAM role name"
+  value       = try(aws_iam_role.scheduled_action[0].name, "")
+}
+
+output "scheduled_action_iam_role_arn" {
+  description = "Scheduled actions IAM role ARN"
+  value       = try(aws_iam_role.scheduled_action[0].arn, "")
+}
+
+output "scheduled_action_iam_role_unique_id" {
+  description = "Stable and unique string identifying the scheduled action IAM role"
+  value       = try(aws_iam_role.scheduled_action[0].unique_id, "")
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,235 +1,358 @@
-variable "cluster_identifier" {
-  description = "Custom name of the cluster"
-  type        = string
-}
-
-variable "cluster_version" {
-  description = "Version of Redshift engine cluster"
-  type        = string
-  default     = "1.0"
-  # Constraints: Only version 1.0 is currently available.
-  # http://docs.aws.amazon.com/cli/latest/reference/redshift/create-cluster.html
-}
-
-variable "cluster_node_type" {
-  description = "Node Type of Redshift cluster"
-  type        = string
-  # Valid Values: dc1.large | dc1.8xlarge | dc2.large | dc2.8xlarge | ds2.xlarge | ds2.8xlarge | ra3.xlplus | ra3.4xlarge | ra3.16xlarge.
-  # http://docs.aws.amazon.com/cli/latest/reference/redshift/create-cluster.html
-}
-
-variable "cluster_number_of_nodes" {
-  description = "Number of nodes in the cluster (values greater than 1 will trigger 'cluster_type' of 'multi-node')"
-  type        = number
-  default     = 3
-}
-
-variable "cluster_database_name" {
-  description = "The name of the database to create"
-  type        = string
-}
-
-variable "cluster_master_username" {
-  description = "Master username"
-  type        = string
-}
-
-variable "cluster_master_password" {
-  description = "Password for master user"
-  type        = string
-}
-
-variable "cluster_port" {
-  description = "Cluster port"
-  type        = number
-  default     = 5439
-}
-
-# This is for a custom parameter to be passed to the DB
-# We're "cloning" default ones, but we need to specify which should be copied
-variable "cluster_parameter_group" {
-  description = "Parameter group, depends on DB engine used"
-  type        = string
-  default     = "redshift-1.0"
-}
-
-variable "cluster_iam_roles" {
-  description = "A list of IAM Role ARNs to associate with the cluster. A Maximum of 10 can be associated to the cluster at any time."
-  type        = list(string)
-  default     = []
-}
-
-variable "publicly_accessible" {
-  description = "Determines if Cluster can be publicly available (NOT recommended)"
-  type        = bool
-  default     = false
-}
-
-variable "redshift_subnet_group_name" {
-  description = "The name of a cluster subnet group to be associated with this cluster. If not specified, new subnet will be created."
-  type        = string
-  default     = ""
-}
-
-variable "parameter_group_name" {
-  description = "The name of the parameter group to be associated with this cluster. If not specified new parameter group will be created."
-  type        = string
-  default     = ""
-}
-
-variable "subnets" {
-  description = "List of subnets DB should be available at. It might be one subnet."
-  type        = list(string)
-  default     = []
-}
-
-variable "vpc_security_group_ids" {
-  description = "A list of Virtual Private Cloud (VPC) security groups to be associated with the cluster."
-  type        = list(string)
-}
-
-variable "final_snapshot_identifier" {
-  description = "(Optional) The identifier of the final snapshot that is to be created immediately before deleting the cluster. If this parameter is provided, 'skip_final_snapshot' must be false."
-  type        = string
-  default     = ""
-}
-
-variable "skip_final_snapshot" {
-  description = "If true (default), no snapshot will be made before deleting DB"
+variable "create" {
+  description = "Determines whether to create Redshift cluster and resources (affects all resources)"
   type        = bool
   default     = true
 }
 
-variable "preferred_maintenance_window" {
-  description = "When AWS can run snapshot, can't overlap with maintenance window"
+variable "tags" {
+  description = "A map of tags to add to all resources"
+  type        = map(string)
+  default     = {}
+}
+
+################################################################################
+# Cluster
+################################################################################
+
+variable "cluster_identifier" {
+  description = "The Cluster Identifier. Must be a lower case string"
   type        = string
-  default     = "sat:10:00-sat:10:30"
+  default     = ""
 }
 
-variable "automated_snapshot_retention_period" {
-  description = "How long will we retain backups"
+variable "cluster_version" {
+  description = "The version of the Amazon Redshift engine software that you want to deploy on the cluster. The version selected runs on all the nodes in the cluster"
+  type        = string
+  default     = null
+}
+
+variable "allow_version_upgrade" {
+  description = "If true , major version upgrades can be applied during the maintenance window to the Amazon Redshift engine that is running on the cluster. Default is `true`"
+  type        = bool
+  default     = null
+}
+
+variable "node_type" {
+  description = "The node type to be provisioned for the cluster"
+  type        = string
+  default     = "dc2.large"
+  # Valid Values: ds2.xlarge | ds2.8xlarge | dc1.large | dc1.8xlarge | dc2.large | dc2.8xlarge | ra3.xlplus | ra3.4xlarge | ra3.16xlarge
+  # https://awscli.amazonaws.com/v2/documentation/api/latest/reference/redshift/create-cluster.html
+}
+
+variable "number_of_nodes" {
+  description = "Number of nodes in the cluster. Defaults to 1. Note: values greater than 1 will trigger `cluster_type` to switch to `multi-node`"
   type        = number
-  default     = 0
+  default     = 1
 }
 
-variable "enable_logging" {
-  description = "Enables logging information such as queries and connection attempts, for the specified Amazon Redshift cluster."
+variable "port" {
+  description = "The port number on which the cluster accepts incoming connections. Default port is 5439"
+  type        = number
+  default     = null
+}
+
+variable "database_name" {
+  description = "The name of the first database to be created when the cluster is created. If you do not provide a name, Amazon Redshift will create a default database called `dev`"
+  type        = string
+  default     = null
+}
+
+variable "master_username" {
+  description = "Username for the master DB user (Required unless a `snapshot_identifier` is provided). Defaults to `awsuser`"
+  type        = string
+  default     = "awsuser"
+}
+
+variable "master_password" {
+  description = "Password for the master DB user. (Required unless a `snapshot_identifier` is provided). Must contain at least 8 chars, one uppercase letter, one lowercase letter, and one number"
+  type        = string
+  default     = null
+  sensitive   = true
+}
+
+variable "iam_roles" {
+  description = "A list of IAM Role ARNs to associate with the cluster. A Maximum of 10 can be associated to the cluster at any time"
+  type        = list(string)
+  default     = []
+}
+
+variable "encrypted" {
+  description = "If true, the data in the cluster is encrypted at rest"
+  type        = bool
+  default     = null
+}
+
+variable "kms_key_arn" {
+  description = "The ARN for the KMS encryption key. When specifying `kms_key_id`, `encrypted` needs to be set to `true`"
+  type        = string
+  default     = null
+}
+
+variable "enhanced_vpc_routing" {
+  description = "If `true`, enhanced VPC routing is enabled"
+  type        = bool
+  default     = null
+}
+
+variable "cluster_security_groups" {
+  description = "A list of security groups to be associated with this cluster"
+  type        = list(string)
+  default     = null
+}
+
+variable "vpc_security_group_ids" {
+  description = "A list of Virtual Private Cloud (VPC) security groups to be associated with the cluster"
+  type        = list(string)
+  default     = null
+}
+
+variable "publicly_accessible" {
+  description = "If true, the cluster can be accessed from a public network"
   type        = bool
   default     = false
 }
 
-variable "logging_bucket_name" {
-  description = "(Optional, required when enable_logging is true) The name of an existing S3 bucket where the log files are to be stored. Must be in the same region as the cluster and the cluster must have read bucket and put object permissions."
+variable "elastic_ip" {
+  description = "The Elastic IP (EIP) address for the cluster"
   type        = string
   default     = null
 }
 
-variable "logging_s3_key_prefix" {
-  description = "(Optional) The prefix applied to the log file names."
+variable "availability_zone" {
+  description = "The EC2 Availability Zone (AZ) in which you want Amazon Redshift to provision the cluster"
   type        = string
   default     = null
 }
 
-# parameter group config bits
-# ref: https://docs.aws.amazon.com/redshift/latest/mgmt/working-with-parameter-groups.html
-variable "enable_user_activity_logging" {
-  description = "Enable logging of user activity. See https://docs.aws.amazon.com/redshift/latest/mgmt/db-auditing.html"
-  type        = string
-  default     = "false"
+variable "availability_zone_relocation_enabled" {
+  description = "If `true`, the cluster can be relocated to another availability zone, either automatically by AWS or when requested. Available for use on clusters from the RA3 instance family."
+  type        = bool
+  default     = false
 }
 
-variable "require_ssl" {
-  description = "Require SSL to connect to this cluster"
+variable "owner_account" {
+  description = "The AWS customer account used to create or copy the snapshot. Required if you are restoring a snapshot you do not own, optional if you own the snapshot"
   type        = string
-  default     = "false"
+  default     = null
 }
 
 variable "snapshot_identifier" {
-  description = "(Optional) The name of the snapshot from which to create the new cluster."
+  description = "The name of the snapshot from which to create the new cluster"
   type        = string
   default     = null
 }
 
 variable "snapshot_cluster_identifier" {
-  description = "(Optional) The name of the cluster the source snapshot was created from."
+  description = "The name of the cluster the source snapshot was created from"
   type        = string
   default     = null
 }
 
-variable "snapshot_copy_destination_region" {
-  description = "(Optional) The name of the region where the snapshot will be copied."
+variable "final_snapshot_identifier" {
+  description = "The identifier of the final snapshot that is to be created immediately before deleting the cluster. If this parameter is provided, `skip_final_snapshot` must be `false`"
   type        = string
   default     = null
 }
 
-variable "snapshot_copy_grant_name" {
-  description = "(Optional) The name of the grant in the destination region. Required if you have a KMS encrypted cluster."
-  type        = string
-  default     = null
-}
-
-variable "owner_account" {
-  description = "(Optional) The AWS customer account used to create or copy the snapshot. Required if you are restoring a snapshot you do not own, optional if you own the snapshot."
-  type        = string
-  default     = null
-}
-
-variable "use_fips_ssl" {
-  description = "Enable FIPS-compliant SSL mode only if your system is required to be FIPS compliant."
-  type        = string
-  default     = "false"
-}
-
-variable "wlm_json_configuration" {
-  description = "Configuration bits for WLM json. see https://docs.aws.amazon.com/redshift/latest/mgmt/workload-mgmt-config.html"
-  type        = string
-  default     = "[{\"query_concurrency\": 5}]"
-}
-
-variable "tags" {
-  description = "A mapping of tags to assign to all resources"
-  type        = map(string)
-  default     = {}
-}
-
-variable "encrypted" {
-  description = "(Optional) If true , the data in the cluster is encrypted at rest."
-  type        = bool
-  default     = false
-}
-
-variable "kms_key_id" {
-  description = "(Optional) The ARN for the KMS encryption key. When specifying kms_key_id, encrypted needs to be set to true."
-  type        = string
-  default     = ""
-}
-
-variable "enhanced_vpc_routing" {
-  description = "(Optional) If true, enhanced VPC routing is enabled."
-  type        = bool
-  default     = false
-}
-
-variable "allow_version_upgrade" {
-  description = "(Optional) If true, major version upgrades can be applied during the maintenance window to the Amazon Redshift engine that is running on the cluster."
+variable "skip_final_snapshot" {
+  description = "Determines whether a final snapshot of the cluster is created before Redshift deletes the cluster. If true, a final cluster snapshot is not created. If false , a final cluster snapshot is created before the cluster is deleted"
   type        = bool
   default     = true
 }
 
-variable "enable_case_sensitive_identifier" {
-  description = "(Optional) A configuration value that determines whether name identifiers of databases, tables, and columns are case sensitive."
+variable "automated_snapshot_retention_period" {
+  description = "The number of days that automated snapshots are retained. If the value is 0, automated snapshots are disabled. Even if automated snapshots are disabled, you can still create manual snapshots when you want with create-cluster-snapshot. Default is 1"
+  type        = number
+  default     = null
+}
+
+variable "preferred_maintenance_window" {
+  description = "The weekly time range (in UTC) during which automated cluster maintenance can occur. Format: `ddd:hh24:mi-ddd:hh24:mi`"
+  type        = string
+  default     = "sat:10:00-sat:10:30"
+}
+
+variable "snapshot_copy" {
+  description = "Configuration of automatic copy of snapshots from one region to another"
+  type        = any
+  default     = {}
+}
+
+variable "logging" {
+  description = "Logging configuration for the cluster"
+  type        = map(string)
+  default     = {}
+}
+
+variable "cluster_timeouts" {
+  description = "Create, update, and delete timeout configurations for the cluster"
+  type        = map(string)
+  default     = {}
+}
+
+################################################################################
+# Paramter Group
+################################################################################
+
+variable "create_parameter_group" {
+  description = "Determines whether to create a parameter group or use existing"
+  type        = bool
+  default     = true
+}
+
+variable "parameter_group_name" {
+  description = "The name of the Redshift parameter group, existing or to be created"
+  type        = string
+  default     = null
+}
+
+variable "parameter_group_description" {
+  description = "The description of the Redshift parameter group. Defaults to `Managed by Terraform`"
+  type        = string
+  default     = null
+}
+
+variable "parameter_group_family" {
+  description = "The family of the Redshift parameter group"
+  type        = string
+  default     = "redshift-1.0"
+}
+
+variable "parameter_group_parameters" {
+  description = "value"
+  type        = map(any)
+  default     = {}
+}
+
+variable "parameter_group_tags" {
+  description = "Additional tags to add to the parameter group"
+  type        = map(string)
+  default     = {}
+}
+
+################################################################################
+# Subnet Group
+################################################################################
+
+variable "create_subnet_group" {
+  description = "Determines whether to create a subnet group or use existing"
+  type        = bool
+  default     = true
+}
+
+variable "subnet_group_name" {
+  description = "The name of the Redshift subnet group, existing or to be created"
+  type        = string
+  default     = null
+}
+
+variable "subnet_group_description" {
+  description = "The description of the Redshift Subnet group. Defaults to `Managed by Terraform`"
+  type        = string
+  default     = null
+}
+
+variable "subnet_ids" {
+  description = "An array of VPC subnet IDs to use in the subnet group"
+  type        = list(string)
+  default     = []
+}
+
+variable "subnet_group_tags" {
+  description = "Additional tags to add to the subnet group"
+  type        = map(string)
+  default     = {}
+}
+
+################################################################################
+# Snapshot Schedule
+################################################################################
+
+variable "create_snapshot_schedule" {
+  description = "Determines whether to create a snapshot schedule"
   type        = bool
   default     = false
 }
 
-variable "max_concurrency_scaling_clusters" {
-  description = "(Optional) Max concurrency scaling clusters parameter (0 to 10)"
-  type        = string
-  default     = "1"
-}
-
-variable "elastic_ip" {
-  description = "(Optional) The Elastic IP (EIP) address for the cluster."
+variable "snapshot_schedule_identifier" {
+  description = "The snapshot schedule identifier"
   type        = string
   default     = null
+}
+
+variable "use_snapshot_identifier_prefix" {
+  description = "Determines whether the identifier (`snapshot_schedule_identifier`) is used as a prefix"
+  type        = bool
+  default     = true
+}
+
+variable "snapshot_schedule_description" {
+  description = "The description of the snapshot schedule"
+  type        = string
+  default     = null
+}
+
+variable "snapshot_schedule_definitions" {
+  description = "The definition of the snapshot schedule. The definition is made up of schedule expressions, for example `cron(30 12 *)` or `rate(12 hours)`"
+  type        = list(string)
+  default     = []
+}
+
+variable "snapshot_schedule_force_destroy" {
+  description = "Whether to destroy all associated clusters with this snapshot schedule on deletion. Must be enabled and applied before attempting deletion"
+  type        = bool
+  default     = null
+}
+
+################################################################################
+# Scheduled Action
+################################################################################
+
+variable "scheduled_actions" {
+  description = "Map of maps containing scheduled action defintions"
+  type        = any
+  default     = {}
+}
+
+variable "create_scheduled_action_iam_role" {
+  description = "Determines whether a scheduled action IAM role is created"
+  type        = bool
+  default     = false
+}
+
+variable "iam_role_name" {
+  description = "Name to use on scheduled action IAM role created"
+  type        = string
+  default     = null
+}
+
+variable "iam_role_use_name_prefix" {
+  description = "Determines whether scheduled action the IAM role name (`iam_role_name`) is used as a prefix"
+  type        = string
+  default     = true
+}
+
+variable "iam_role_path" {
+  description = "Scheduled action IAM role path"
+  type        = string
+  default     = null
+}
+
+variable "iam_role_description" {
+  description = "Description of the scheduled action IAM role"
+  type        = string
+  default     = null
+}
+
+variable "iam_role_permissions_boundary" {
+  description = "ARN of the policy that is used to set the permissions boundary for the scheduled action IAM role"
+  type        = string
+  default     = null
+}
+
+variable "iam_role_tags" {
+  description = "A map of additional tags to add to the scheduled action IAM role created"
+  type        = map(string)
+  default     = {}
 }

--- a/versions.tf
+++ b/versions.tf
@@ -1,7 +1,14 @@
 terraform {
-  required_version = ">= 0.12.31"
+  required_version = ">= 0.13.1"
 
   required_providers {
-    aws = ">= 3.57.0"
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 4.6"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = ">= 3.0"
+    }
   }
 }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Added new resources introduces in provider version 4.6.
Added availability_zone_relocation_enabled into aws_redshift_cluster
Added aws_redshift_snapshot_schedule, aws_redshift_snapshot_schedule_association, aws_redshift_scheduled_action, aws_iam_role.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
availability_zone_relocation_enabled is needed in order to consume the same redshift cluster from other azs,
schedules actions are nice to have.
<!--- If it fixes an open issue, please link to the issue here. -->


## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
No.
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
- [ X] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ X] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [X ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
