### PR TITLE
fix: Attach IAM roles to cluster regardless of setting a default role

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -101,7 +101,7 @@ resource "aws_redshift_cluster" "this" {
 ################################################################################
 
 resource "aws_redshift_cluster_iam_roles" "this" {
-  count = var.create && length(var.iam_role_arns) > 0 && var.default_iam_role_arn != null ? 1 : 0
+  count = var.create && length(var.iam_role_arns) > 0 ? 1 : 0
 
   cluster_identifier   = aws_redshift_cluster.this[0].id
   iam_role_arns        = var.iam_role_arns


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

Remove the condition that requires a default IAM role to be defined in order to attach roles to the Redshift cluster; the default role is optional (see https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/redshift_cluster_iam_roles#default_iam_role_arn).

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

I have a Redshift cluster with several IAM roles attached, but I do not define a default role. Currently the condition attached to the `aws_redshift_cluster_iam_roles.this` resource excludes this use case, causing me to have to define the resource outside the module (without the condition).

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

No breaking changes

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->

- [x] Successfully deployed in own environment with this change, without specifying a default 