### PR TITLE
fix: Master username when specifying snapshot identifier

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -60,7 +60,7 @@ resource "aws_redshift_cluster" "this" {
   maintenance_track_name           = var.maintenance_track_name
   manual_snapshot_retention_period = var.manual_snapshot_retention_period
   master_password                  = var.snapshot_identifier != null ? null : local.master_password
-  master_username                  = var.snapshot_identifier != null ? null : var.master_username
+  master_username                  = var.master_username
   node_type                        = var.node_type
   number_of_nodes                  = var.number_of_nodes
   owner_account                    = var.owner_account


### PR DESCRIPTION
## Description
In the steps below, the cluster with the difference will be recreated.

1 - specify snapshot_identifier, terraform apply
2 - same condition, terraform plan

```
$ terraform plan
  ...
  # module.redshift.aws_redshift_cluster.this[0] must be replaced
-/+ resource "aws_redshift_cluster" "this" {
      ...
      - master_username                      = "master" -> null # forces replacement
      ...
```

## Motivation and Context
We want to restore the cluster from a snapshot. 
However, I have this problem and am looking for a solution.

## Breaking Changes
It will affect cases where both master_username and snapshot_identifier are specified.

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
