### PR TITLE
fix: Master password autogen constraints to match AWS requirements

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -3,12 +3,13 @@ data "aws_partition" "current" {}
 resource "random_password" "master_password" {
   count = var.create && var.create_random_password ? 1 : 0
 
-  length      = var.random_password_length
-  min_lower   = 1
-  min_numeric = 1
-  min_special = 1
-  min_upper   = 1
-  special     = false
+  length           = var.random_password_length
+  min_lower        = 1
+  min_numeric      = 1
+  min_special      = 1
+  min_upper        = 1
+  special          = true
+  override_special = "!#$%&*()-_=+[]{}<>:?"
 }
 
 ################################################################################


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
The issue is mentioned in #71 
Basically, when specifying the **master_password**, AWS has constraints that
- Must be between 8 and 64 characters in length.
- Must contain at least one uppercase letter.
- Must contain at least one lowercase letter.
- Must contain one number.
- Can be any printable ASCII character (ASCII code 33-126) except ' (single quote), " (double quote), \, /, or @.

Currently, we have the attribute `min_special` (sets as `1`) which overrides the `special` (sets as `false`) and randomly assigns the constraints characters as mentioned above.


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
We want to use the built-in attribute `create_random_password` without having our custom `random_password` resource.

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->
It does not break any backwards compatibility as `master_password` is currently under `lifecycle's ignore_changes`. 

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
