### PR TITLE
Issue 77

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -37,6 +37,7 @@ resource "aws_redshift_cluster" "this" {
   cluster_subnet_group_name            = local.subnet_group_name
   cluster_type                         = var.number_of_nodes > 1 ? "multi-node" : "single-node"
   cluster_version                      = var.cluster_version
+  cluster_revision_number              = var.cluster_revision_number
   database_name                        = var.database_name
   elastic_ip                           = var.elastic_ip
   encrypted                            = var.encrypted

--- a/outputs.tf
+++ b/outputs.tf
@@ -91,6 +91,11 @@ output "cluster_version" {
   value       = try(aws_redshift_cluster.this[0].cluster_version, "")
 }
 
+output "cluster_revision_number" {
+  description = "The specific revision number of the database in the cluster"
+  value       = try(aws_redshift_cluster.this[0].cluster_revision_number, "")
+}
+
 output "cluster_parameter_group_name" {
   description = "The name of the parameter group to be associated with this cluster"
   value       = try(aws_redshift_cluster.this[0].cluster_parameter_group_name, "")

--- a/outputs.tf
+++ b/outputs.tf
@@ -91,11 +91,6 @@ output "cluster_version" {
   value       = try(aws_redshift_cluster.this[0].cluster_version, "")
 }
 
-output "cluster_revision_number" {
-  description = "The specific revision number of the database in the cluster"
-  value       = try(aws_redshift_cluster.this[0].cluster_revision_number, "")
-}
-
 output "cluster_parameter_group_name" {
   description = "The name of the parameter group to be associated with this cluster"
   value       = try(aws_redshift_cluster.this[0].cluster_parameter_group_name, "")

--- a/variables.tf
+++ b/variables.tf
@@ -65,6 +65,12 @@ variable "cluster_version" {
   default     = null
 }
 
+variable "cluster_revision_number" {
+  description = "The specific revision number of the database in the cluster"
+  type        = string
+  default     = null
+}
+
 variable "database_name" {
   description = "The name of the first database to be created when the cluster is created. If you do not provide a name, Amazon Redshift will create a default database called `dev`"
   type        = string


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
I added the cluster revision number property to the variable list and also modified the main.tf file to use the new variable.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
After creating the Redshift cluster terraform adds cluster_revision_number to the state. This revision number changes when AWS updates the cluster version, but Terraform tries to change it back to the old revision number used before the update even though the allow_version_upgrade property is set to true.

IT fixes the following issue: https://github.com/terraform-aws-modules/terraform-aws-redshift/issues/77

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
- [X] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
