### PR TITLE
feat: Permit to modify the name and the description of the Parameter Group

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -128,6 +128,10 @@ resource "aws_redshift_parameter_group" "this" {
     }
   }
 
+  lifecycle {
+    create_before_destroy = true
+  }
+
   tags = merge(var.tags, var.parameter_group_tags)
 }
 


### PR DESCRIPTION
## Description
Permit to modify the name and the description of the Parameter Group.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Currently, we cannot modify the parameter group name. The module tries to destroy first, and AWS API creates an error.
```
~ resource "aws_redshift_cluster" "this" {
      ~ cluster_parameter_group_name         = "DummyName" -> (known after apply)
        id                                   = "xxxx"
```

```
│ Error: creating Redshift Parameter Group (DummyName): ClusterParameterGroupAlreadyExists: Parameter group DummyName already exists
│ 	status code: 400, request id: xxxx-xxxxx-xxxx-xxxx
│ 
│   with module.redshift.aws_redshift_parameter_group.this[0],
│   on .terraform/modules/redshift/main.tf line 115, in resource "aws_redshift_parameter_group" "this":
│  115: resource "aws_redshift_parameter_group" "this" {
```

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->
No

## How Has This Been Tested?
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
- [x] I did a migration from 2.0.0 to 4.0.3 updating the current Parameter Group created previously by the module.
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
