### PR TITLE
chore: Snapshot_copy does not work as per example 

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,10 +30,9 @@ module "redshift" {
   availability_zone_relocation_enabled = true
 
   snapshot_copy = {
-    useast1 = {
       destination_region = "us-east-1"
       grant_name         = "example-grant"
-    }
+      retention_period   = 1
   }
 
   logging = {

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -48,10 +48,9 @@ module "redshift" {
   availability_zone_relocation_enabled = true
 
   snapshot_copy = {
-    useast1 = {
       destination_region = "us-east-1"
       grant_name         = aws_redshift_snapshot_copy_grant.useast1.snapshot_copy_grant_name
-    }
+      rentention_period  = 1
   }
 
   logging = {

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -48,9 +48,9 @@ module "redshift" {
   availability_zone_relocation_enabled = true
 
   snapshot_copy = {
-      destination_region = "us-east-1"
-      grant_name         = aws_redshift_snapshot_copy_grant.useast1.snapshot_copy_grant_name
-      rentention_period  = 1
+    destination_region = "us-east-1"
+    grant_name         = aws_redshift_snapshot_copy_grant.useast1.snapshot_copy_grant_name
+    rentention_period  = 1
   }
 
   logging = {


### PR DESCRIPTION
## Description
See [https://github.com/terraform-aws-modules/terraform-aws-redshift/issues/73](https://github.com/terraform-aws-modules/terraform-aws-redshift/issues/73)

The snapshot_copy functionality does not work as per [examples/complete/main.tf](https://github.com/terraform-aws-modules/terraform-aws-redshift/blob/v4.0.3/examples/complete/main.tf)

This does NOT work:

```
  snapshot_copy = {
    useast1 = {
      destination_region = "us-east-1"
      grant_name         = aws_redshift_snapshot_copy_grant.useast1.snapshot_copy_grant_name
    }
  }
```
This works:

```
  snapshot_copy = {
    destination_region = "us-east-1"
    grant_name         = aws_redshift_snapshot_copy_grant.useast1.snapshot_copy_grant_name
    retention_period   = 1
  }
```


## Motivation and Context
Open issue here: https://github.com/terraform-aws-modules/terraform-aws-redshift/issues/73

## Breaking Changes
No breaking changes

## How Has This Been Tested?
- [ x ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ x ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ x ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
