### PR TITLE
feat!: Remove deprecated EC2 classic fields removed in AWS provider v5.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.76.0
+    rev: v1.80.0
     hooks:
       - id: terraform_fmt
       - id: terraform_validate
@@ -23,7 +23,7 @@ repos:
           - '--args=--only=terraform_standard_module_structure'
           - '--args=--only=terraform_workspace_remote'
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.3.0
+    rev: v4.4.0
     hooks:
       - id: check-merge-conflict
       - id: end-of-file-fixer

--- a/README.md
+++ b/README.md
@@ -30,10 +30,8 @@ module "redshift" {
   availability_zone_relocation_enabled = true
 
   snapshot_copy = {
-    useast1 = {
-      destination_region = "us-east-1"
-      grant_name         = "example-grant"
-    }
+    destination_region = "us-east-1"
+    grant_name         = "example-grant"
   }
 
   logging = {
@@ -181,14 +179,14 @@ module "redshift" {
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.17 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.17 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.0 |
 | <a name="provider_random"></a> [random](#provider\_random) | >= 3.0 |
 
 ## Modules
@@ -226,7 +224,7 @@ No modules.
 | <a name="input_authentication_profiles"></a> [authentication\_profiles](#input\_authentication\_profiles) | Map of authentication profiles to create | `any` | `{}` | no |
 | <a name="input_automated_snapshot_retention_period"></a> [automated\_snapshot\_retention\_period](#input\_automated\_snapshot\_retention\_period) | The number of days that automated snapshots are retained. If the value is 0, automated snapshots are disabled. Even if automated snapshots are disabled, you can still create manual snapshots when you want with create-cluster-snapshot. Default is 1 | `number` | `null` | no |
 | <a name="input_availability_zone"></a> [availability\_zone](#input\_availability\_zone) | The EC2 Availability Zone (AZ) in which you want Amazon Redshift to provision the cluster. Can only be changed if `availability_zone_relocation_enabled` is `true` | `string` | `null` | no |
-| <a name="input_availability_zone_relocation_enabled"></a> [availability\_zone\_relocation\_enabled](#input\_availability\_zone\_relocation\_enabled) | If `true`, the cluster can be relocated to another availabity zone, either automatically by AWS or when requested. Default is `false`. Available for use on clusters from the RA3 instance family | `bool` | `null` | no |
+| <a name="input_availability_zone_relocation_enabled"></a> [availability\_zone\_relocation\_enabled](#input\_availability\_zone\_relocation\_enabled) | If `true`, the cluster can be relocated to another availability zone, either automatically by AWS or when requested. Default is `false`. Available for use on clusters from the RA3 instance family | `bool` | `null` | no |
 | <a name="input_cluster_identifier"></a> [cluster\_identifier](#input\_cluster\_identifier) | The Cluster Identifier. Must be a lower case string | `string` | `""` | no |
 | <a name="input_cluster_timeouts"></a> [cluster\_timeouts](#input\_cluster\_timeouts) | Create, update, and delete timeout configurations for the cluster | `map(string)` | `{}` | no |
 | <a name="input_cluster_version"></a> [cluster\_version](#input\_cluster\_version) | The version of the Amazon Redshift engine software that you want to deploy on the cluster. The version selected runs on all the nodes in the cluster | `string` | `null` | no |
@@ -272,7 +270,7 @@ No modules.
 | <a name="input_preferred_maintenance_window"></a> [preferred\_maintenance\_window](#input\_preferred\_maintenance\_window) | The weekly time range (in UTC) during which automated cluster maintenance can occur. Format: `ddd:hh24:mi-ddd:hh24:mi` | `string` | `"sat:10:00-sat:10:30"` | no |
 | <a name="input_publicly_accessible"></a> [publicly\_accessible](#input\_publicly\_accessible) | If true, the cluster can be accessed from a public network | `bool` | `false` | no |
 | <a name="input_random_password_length"></a> [random\_password\_length](#input\_random\_password\_length) | Length of random password to create. Defaults to `16` | `number` | `16` | no |
-| <a name="input_scheduled_actions"></a> [scheduled\_actions](#input\_scheduled\_actions) | Map of maps containing scheduled action defintions | `any` | `{}` | no |
+| <a name="input_scheduled_actions"></a> [scheduled\_actions](#input\_scheduled\_actions) | Map of maps containing scheduled action definitions | `any` | `{}` | no |
 | <a name="input_skip_final_snapshot"></a> [skip\_final\_snapshot](#input\_skip\_final\_snapshot) | Determines whether a final snapshot of the cluster is created before Redshift deletes the cluster. If true, a final cluster snapshot is not created. If false , a final cluster snapshot is created before the cluster is deleted | `bool` | `true` | no |
 | <a name="input_snapshot_cluster_identifier"></a> [snapshot\_cluster\_identifier](#input\_snapshot\_cluster\_identifier) | The name of the cluster the source snapshot was created from | `string` | `null` | no |
 | <a name="input_snapshot_copy"></a> [snapshot\_copy](#input\_snapshot\_copy) | Configuration of automatic copy of snapshots from one region to another | `any` | `{}` | no |
@@ -286,7 +284,7 @@ No modules.
 | <a name="input_subnet_group_tags"></a> [subnet\_group\_tags](#input\_subnet\_group\_tags) | Additional tags to add to the subnet group | `map(string)` | `{}` | no |
 | <a name="input_subnet_ids"></a> [subnet\_ids](#input\_subnet\_ids) | An array of VPC subnet IDs to use in the subnet group | `list(string)` | `[]` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to add to all resources | `map(string)` | `{}` | no |
-| <a name="input_usage_limits"></a> [usage\_limits](#input\_usage\_limits) | Map of usage limit defintions to create | `any` | `{}` | no |
+| <a name="input_usage_limits"></a> [usage\_limits](#input\_usage\_limits) | Map of usage limit definitions to create | `any` | `{}` | no |
 | <a name="input_use_snapshot_identifier_prefix"></a> [use\_snapshot\_identifier\_prefix](#input\_use\_snapshot\_identifier\_prefix) | Determines whether the identifier (`snapshot_schedule_identifier`) is used as a prefix | `bool` | `true` | no |
 | <a name="input_vpc_security_group_ids"></a> [vpc\_security\_group\_ids](#input\_vpc\_security\_group\_ids) | A list of Virtual Private Cloud (VPC) security groups to be associated with the cluster | `list(string)` | `[]` | no |
 

--- a/README.md
+++ b/README.md
@@ -312,7 +312,6 @@ No modules.
 | <a name="output_cluster_preferred_maintenance_window"></a> [cluster\_preferred\_maintenance\_window](#output\_cluster\_preferred\_maintenance\_window) | The backup window |
 | <a name="output_cluster_public_key"></a> [cluster\_public\_key](#output\_cluster\_public\_key) | The public key for the cluster |
 | <a name="output_cluster_revision_number"></a> [cluster\_revision\_number](#output\_cluster\_revision\_number) | The specific revision number of the database in the cluster |
-| <a name="output_cluster_security_groups"></a> [cluster\_security\_groups](#output\_cluster\_security\_groups) | The security groups associated with the cluster |
 | <a name="output_cluster_subnet_group_name"></a> [cluster\_subnet\_group\_name](#output\_cluster\_subnet\_group\_name) | The name of a cluster subnet group to be associated with this cluster |
 | <a name="output_cluster_type"></a> [cluster\_type](#output\_cluster\_type) | The Redshift cluster type |
 | <a name="output_cluster_version"></a> [cluster\_version](#output\_cluster\_version) | The version of Redshift engine software |

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -84,7 +84,6 @@ No inputs.
 | <a name="output_cluster_preferred_maintenance_window"></a> [cluster\_preferred\_maintenance\_window](#output\_cluster\_preferred\_maintenance\_window) | The backup window |
 | <a name="output_cluster_public_key"></a> [cluster\_public\_key](#output\_cluster\_public\_key) | The public key for the cluster |
 | <a name="output_cluster_revision_number"></a> [cluster\_revision\_number](#output\_cluster\_revision\_number) | The specific revision number of the database in the cluster |
-| <a name="output_cluster_security_groups"></a> [cluster\_security\_groups](#output\_cluster\_security\_groups) | The security groups associated with the cluster |
 | <a name="output_cluster_subnet_group_name"></a> [cluster\_subnet\_group\_name](#output\_cluster\_subnet\_group\_name) | The name of a cluster subnet group to be associated with this cluster |
 | <a name="output_cluster_type"></a> [cluster\_type](#output\_cluster\_type) | The Redshift cluster type |
 | <a name="output_cluster_version"></a> [cluster\_version](#output\_cluster\_version) | The version of Redshift engine software |

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -24,16 +24,14 @@ Note that this example may create resources which cost money. Run `terraform des
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.17 |
-| <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.17 |
-| <a name="provider_aws.us_east_1"></a> [aws.us\_east\_1](#provider\_aws.us\_east\_1) | >= 4.17 |
-| <a name="provider_random"></a> [random](#provider\_random) | >= 3.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.0 |
+| <a name="provider_aws.us_east_1"></a> [aws.us\_east\_1](#provider\_aws.us\_east\_1) | >= 5.0 |
 
 ## Modules
 
@@ -43,8 +41,8 @@ Note that this example may create resources which cost money. Run `terraform des
 | <a name="module_disabled"></a> [disabled](#module\_disabled) | ../../ | n/a |
 | <a name="module_redshift"></a> [redshift](#module\_redshift) | ../../ | n/a |
 | <a name="module_s3_logs"></a> [s3\_logs](#module\_s3\_logs) | terraform-aws-modules/s3-bucket/aws | ~> 3.0 |
-| <a name="module_security_group"></a> [security\_group](#module\_security\_group) | terraform-aws-modules/security-group/aws//modules/redshift | ~> 4.0 |
-| <a name="module_vpc"></a> [vpc](#module\_vpc) | terraform-aws-modules/vpc/aws | ~> 3.0 |
+| <a name="module_security_group"></a> [security\_group](#module\_security\_group) | terraform-aws-modules/security-group/aws//modules/redshift | ~> 5.0 |
+| <a name="module_vpc"></a> [vpc](#module\_vpc) | terraform-aws-modules/vpc/aws | ~> 5.0 |
 
 ## Resources
 
@@ -54,9 +52,8 @@ Note that this example may create resources which cost money. Run `terraform des
 | [aws_kms_key.redshift_us_east_1](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_key) | resource |
 | [aws_redshift_snapshot_copy_grant.useast1](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/redshift_snapshot_copy_grant) | resource |
 | [aws_redshift_subnet_group.endpoint](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/redshift_subnet_group) | resource |
-| [random_pet.this](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/pet) | resource |
+| [aws_availability_zones.available](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/availability_zones) | data source |
 | [aws_iam_policy_document.s3_redshift](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
-| [aws_redshift_service_account.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/redshift_service_account) | data source |
 
 ## Inputs
 

--- a/examples/complete/outputs.tf
+++ b/examples/complete/outputs.tf
@@ -62,11 +62,6 @@ output "cluster_encrypted" {
   value       = module.redshift.cluster_encrypted
 }
 
-output "cluster_security_groups" {
-  description = "The security groups associated with the cluster"
-  value       = module.redshift.cluster_security_groups
-}
-
 output "cluster_vpc_security_group_ids" {
   description = "The VPC security group ids associated with the cluster"
   value       = module.redshift.cluster_vpc_security_group_ids

--- a/examples/complete/versions.tf
+++ b/examples/complete/versions.tf
@@ -4,11 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.17"
-    }
-    random = {
-      source  = "hashicorp/random"
-      version = ">= 3.0"
+      version = ">= 5.0"
     }
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -72,7 +72,7 @@ resource "aws_redshift_cluster" "this" {
   snapshot_cluster_identifier      = var.snapshot_cluster_identifier
 
   dynamic "snapshot_copy" {
-    for_each = can(var.snapshot_copy.destination_region) ? [var.snapshot_copy] : []
+    for_each = length(var.snapshot_copy) > 0 ? [var.snapshot_copy] : []
 
     content {
       destination_region = snapshot_copy.value.destination_region
@@ -189,7 +189,7 @@ resource "aws_redshift_scheduled_action" "this" {
 
   target_action {
     dynamic "pause_cluster" {
-      for_each = can(each.value.pause_cluster) ? [each.value.pause_cluster] : []
+      for_each = try([each.value.pause_cluster], [])
 
       content {
         cluster_identifier = aws_redshift_cluster.this[0].id
@@ -197,7 +197,7 @@ resource "aws_redshift_scheduled_action" "this" {
     }
 
     dynamic "resize_cluster" {
-      for_each = can(each.value.resize_cluster) ? [each.value.resize_cluster] : []
+      for_each = try([each.value.resize_cluster], [])
 
       content {
         classic            = try(resize_cluster.value.classic, null)
@@ -209,7 +209,7 @@ resource "aws_redshift_scheduled_action" "this" {
     }
 
     dynamic "resume_cluster" {
-      for_each = can(each.value.resume_cluster) ? [each.value.resume_cluster] : []
+      for_each = try([each.value.resume_cluster], [])
 
       content {
         cluster_identifier = aws_redshift_cluster.this[0].id

--- a/outputs.tf
+++ b/outputs.tf
@@ -4,52 +4,52 @@
 
 output "cluster_arn" {
   description = "The Redshift cluster ARN"
-  value       = try(aws_redshift_cluster.this[0].arn, "")
+  value       = try(aws_redshift_cluster.this[0].arn, null)
 }
 
 output "cluster_id" {
   description = "The Redshift cluster ID"
-  value       = try(aws_redshift_cluster.this[0].id, "")
+  value       = try(aws_redshift_cluster.this[0].id, null)
 }
 
 output "cluster_identifier" {
   description = "The Redshift cluster identifier"
-  value       = try(aws_redshift_cluster.this[0].cluster_identifier, "")
+  value       = try(aws_redshift_cluster.this[0].cluster_identifier, null)
 }
 
 output "cluster_type" {
   description = "The Redshift cluster type"
-  value       = try(aws_redshift_cluster.this[0].cluster_type, "")
+  value       = try(aws_redshift_cluster.this[0].cluster_type, null)
 }
 
 output "cluster_node_type" {
   description = "The type of nodes in the cluster"
-  value       = try(aws_redshift_cluster.this[0].node_type, "")
+  value       = try(aws_redshift_cluster.this[0].node_type, null)
 }
 
 output "cluster_database_name" {
   description = "The name of the default database in the Cluster"
-  value       = try(aws_redshift_cluster.this[0].database_name, "")
+  value       = try(aws_redshift_cluster.this[0].database_name, null)
 }
 
 output "cluster_availability_zone" {
   description = "The availability zone of the Cluster"
-  value       = try(aws_redshift_cluster.this[0].availability_zone, "")
+  value       = try(aws_redshift_cluster.this[0].availability_zone, null)
 }
 
 output "cluster_automated_snapshot_retention_period" {
   description = "The backup retention period"
-  value       = try(aws_redshift_cluster.this[0].automated_snapshot_retention_period, "")
+  value       = try(aws_redshift_cluster.this[0].automated_snapshot_retention_period, null)
 }
 
 output "cluster_preferred_maintenance_window" {
   description = "The backup window"
-  value       = try(aws_redshift_cluster.this[0].preferred_maintenance_window, "")
+  value       = try(aws_redshift_cluster.this[0].preferred_maintenance_window, null)
 }
 
 output "cluster_endpoint" {
   description = "The connection endpoint"
-  value       = try(aws_redshift_cluster.this[0].endpoint, "")
+  value       = try(aws_redshift_cluster.this[0].endpoint, null)
 }
 
 output "cluster_hostname" {
@@ -63,7 +63,7 @@ output "cluster_hostname" {
 
 output "cluster_encrypted" {
   description = "Whether the data in the cluster is encrypted"
-  value       = try(aws_redshift_cluster.this[0].encrypted, "")
+  value       = try(aws_redshift_cluster.this[0].encrypted, null)
 }
 
 output "cluster_vpc_security_group_ids" {
@@ -73,37 +73,37 @@ output "cluster_vpc_security_group_ids" {
 
 output "cluster_dns_name" {
   description = "The DNS name of the cluster"
-  value       = try(aws_redshift_cluster.this[0].dns_name, "")
+  value       = try(aws_redshift_cluster.this[0].dns_name, null)
 }
 
 output "cluster_port" {
   description = "The port the cluster responds on"
-  value       = try(aws_redshift_cluster.this[0].port, "")
+  value       = try(aws_redshift_cluster.this[0].port, null)
 }
 
 output "cluster_version" {
   description = "The version of Redshift engine software"
-  value       = try(aws_redshift_cluster.this[0].cluster_version, "")
+  value       = try(aws_redshift_cluster.this[0].cluster_version, null)
 }
 
 output "cluster_parameter_group_name" {
   description = "The name of the parameter group to be associated with this cluster"
-  value       = try(aws_redshift_cluster.this[0].cluster_parameter_group_name, "")
+  value       = try(aws_redshift_cluster.this[0].cluster_parameter_group_name, null)
 }
 
 output "cluster_subnet_group_name" {
   description = "The name of a cluster subnet group to be associated with this cluster"
-  value       = try(aws_redshift_cluster.this[0].cluster_subnet_group_name, "")
+  value       = try(aws_redshift_cluster.this[0].cluster_subnet_group_name, null)
 }
 
 output "cluster_public_key" {
   description = "The public key for the cluster"
-  value       = try(aws_redshift_cluster.this[0].cluster_public_key, "")
+  value       = try(aws_redshift_cluster.this[0].cluster_public_key, null)
 }
 
 output "cluster_revision_number" {
   description = "The specific revision number of the database in the cluster"
-  value       = try(aws_redshift_cluster.this[0].cluster_revision_number, "")
+  value       = try(aws_redshift_cluster.this[0].cluster_revision_number, null)
 }
 
 output "cluster_nodes" {
@@ -117,12 +117,12 @@ output "cluster_nodes" {
 
 output "parameter_group_arn" {
   description = "Amazon Resource Name (ARN) of the parameter group created"
-  value       = try(aws_redshift_parameter_group.this[0].arn, "")
+  value       = try(aws_redshift_parameter_group.this[0].arn, null)
 }
 
 output "parameter_group_id" {
   description = "The name of the Redshift parameter group created"
-  value       = try(aws_redshift_parameter_group.this[0].id, "")
+  value       = try(aws_redshift_parameter_group.this[0].id, null)
 }
 
 ################################################################################
@@ -131,12 +131,12 @@ output "parameter_group_id" {
 
 output "subnet_group_arn" {
   description = "Amazon Resource Name (ARN) of the Redshift subnet group created"
-  value       = try(aws_redshift_subnet_group.this[0].arn, "")
+  value       = try(aws_redshift_subnet_group.this[0].arn, null)
 }
 
 output "subnet_group_id" {
   description = "The ID of Redshift Subnet group created"
-  value       = try(aws_redshift_subnet_group.this[0].id, "")
+  value       = try(aws_redshift_subnet_group.this[0].id, null)
 }
 
 ################################################################################
@@ -145,7 +145,7 @@ output "subnet_group_id" {
 
 output "snapshot_schedule_arn" {
   description = "Amazon Resource Name (ARN) of the Redshift Snapshot Schedule"
-  value       = try(aws_redshift_snapshot_schedule.this[0].arn, "")
+  value       = try(aws_redshift_snapshot_schedule.this[0].arn, null)
 }
 
 ################################################################################
@@ -159,17 +159,17 @@ output "scheduled_actions" {
 
 output "scheduled_action_iam_role_name" {
   description = "Scheduled actions IAM role name"
-  value       = try(aws_iam_role.scheduled_action[0].name, "")
+  value       = try(aws_iam_role.scheduled_action[0].name, null)
 }
 
 output "scheduled_action_iam_role_arn" {
   description = "Scheduled actions IAM role ARN"
-  value       = try(aws_iam_role.scheduled_action[0].arn, "")
+  value       = try(aws_iam_role.scheduled_action[0].arn, null)
 }
 
 output "scheduled_action_iam_role_unique_id" {
   description = "Stable and unique string identifying the scheduled action IAM role"
-  value       = try(aws_iam_role.scheduled_action[0].unique_id, "")
+  value       = try(aws_iam_role.scheduled_action[0].unique_id, null)
 }
 
 ################################################################################
@@ -178,22 +178,22 @@ output "scheduled_action_iam_role_unique_id" {
 
 output "endpoint_access_address" {
   description = "The DNS address of the endpoint"
-  value       = try(aws_redshift_endpoint_access.this[0].address, "")
+  value       = try(aws_redshift_endpoint_access.this[0].address, null)
 }
 
 output "endpoint_access_id" {
   description = "The Redshift-managed VPC endpoint name"
-  value       = try(aws_redshift_endpoint_access.this[0].id, "")
+  value       = try(aws_redshift_endpoint_access.this[0].id, null)
 }
 
 output "endpoint_access_port" {
   description = "The port number on which the cluster accepts incoming connections"
-  value       = try(aws_redshift_endpoint_access.this[0].port, "")
+  value       = try(aws_redshift_endpoint_access.this[0].port, null)
 }
 
 output "endpoint_access_vpc_endpoint" {
   description = "The connection endpoint for connecting to an Amazon Redshift cluster through the proxy. See details below"
-  value       = try(aws_redshift_endpoint_access.this[0].vpc_endpoint, "")
+  value       = try(aws_redshift_endpoint_access.this[0].vpc_endpoint, null)
 }
 
 ################################################################################

--- a/outputs.tf
+++ b/outputs.tf
@@ -66,11 +66,6 @@ output "cluster_encrypted" {
   value       = try(aws_redshift_cluster.this[0].encrypted, "")
 }
 
-output "cluster_security_groups" {
-  description = "The security groups associated with the cluster"
-  value       = try(aws_redshift_cluster.this[0].cluster_security_groups, [])
-}
-
 output "cluster_vpc_security_group_ids" {
   description = "The VPC security group ids associated with the cluster"
   value       = try(aws_redshift_cluster.this[0].vpc_security_group_ids, [])

--- a/variables.tf
+++ b/variables.tf
@@ -45,7 +45,7 @@ variable "availability_zone" {
 }
 
 variable "availability_zone_relocation_enabled" {
-  description = "If `true`, the cluster can be relocated to another availabity zone, either automatically by AWS or when requested. Default is `false`. Available for use on clusters from the RA3 instance family"
+  description = "If `true`, the cluster can be relocated to another availability zone, either automatically by AWS or when requested. Default is `false`. Available for use on clusters from the RA3 instance family"
   type        = bool
   default     = null
 }
@@ -355,7 +355,7 @@ variable "snapshot_schedule_force_destroy" {
 ################################################################################
 
 variable "scheduled_actions" {
-  description = "Map of maps containing scheduled action defintions"
+  description = "Map of maps containing scheduled action definitions"
   type        = any
   default     = {}
 }
@@ -441,7 +441,7 @@ variable "endpoint_vpc_security_group_ids" {
 ################################################################################
 
 variable "usage_limits" {
-  description = "Map of usage limit defintions to create"
+  description = "Map of usage limit definitions to create"
   type        = any
   default     = {}
 }

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.17"
+      version = ">= 5.0"
     }
     random = {
       source  = "hashicorp/random"


### PR DESCRIPTION
## Description

- Remove deprecated EC2 classic fields removed in AWS provider v5.0
- Raise AWS provider minimum supported version to v5.0
- Update and validate example

## Motivation and Context

- Resolves #73
- Resolves #84
- Resolves #85

## Breaking Changes
- Yes; provider minimum supported raised to v5.0 which removes the deprecated fields 
