### PR TITLE
feat: Add managed secrets option

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,14 +179,14 @@ module "redshift" {
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.24 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.24 |
 | <a name="provider_random"></a> [random](#provider\_random) | >= 3.0 |
 
 ## Modules
@@ -255,8 +255,10 @@ No modules.
 | <a name="input_kms_key_arn"></a> [kms\_key\_arn](#input\_kms\_key\_arn) | The ARN for the KMS encryption key. When specifying `kms_key_arn`, `encrypted` needs to be set to `true` | `string` | `null` | no |
 | <a name="input_logging"></a> [logging](#input\_logging) | Logging configuration for the cluster | `any` | `{}` | no |
 | <a name="input_maintenance_track_name"></a> [maintenance\_track\_name](#input\_maintenance\_track\_name) | The name of the maintenance track for the restored cluster. When you take a snapshot, the snapshot inherits the MaintenanceTrack value from the cluster. The snapshot might be on a different track than the cluster that was the source for the snapshot. Default value is `current` | `string` | `null` | no |
+| <a name="input_manage_master_password"></a> [manage\_master\_password](#input\_manage\_master\_password) | (Optional) Whether to use AWS SecretsManager to manage the cluster admin credentials. Conflicts with master\_password. One of master\_password or manage\_master\_password is required unless snapshot\_identifier is provided. | `bool` | `null` | no |
 | <a name="input_manual_snapshot_retention_period"></a> [manual\_snapshot\_retention\_period](#input\_manual\_snapshot\_retention\_period) | The default number of days to retain a manual snapshot. If the value is -1, the snapshot is retained indefinitely. This setting doesn't change the retention period of existing snapshots. Valid values are between `-1` and `3653`. Default value is `-1` | `number` | `null` | no |
 | <a name="input_master_password"></a> [master\_password](#input\_master\_password) | Password for the master DB user. (Required unless a `snapshot_identifier` is provided). Must contain at least 8 chars, one uppercase letter, one lowercase letter, and one number | `string` | `null` | no |
+| <a name="input_master_password_secret_kms_key_id"></a> [master\_password\_secret\_kms\_key\_id](#input\_master\_password\_secret\_kms\_key\_id) | (Optional) ID of the KMS key used to encrypt the cluster admin credentials secret. | `string` | `null` | no |
 | <a name="input_master_username"></a> [master\_username](#input\_master\_username) | Username for the master DB user (Required unless a `snapshot_identifier` is provided). Defaults to `awsuser` | `string` | `"awsuser"` | no |
 | <a name="input_node_type"></a> [node\_type](#input\_node\_type) | The node type to be provisioned for the cluster | `string` | `""` | no |
 | <a name="input_number_of_nodes"></a> [number\_of\_nodes](#input\_number\_of\_nodes) | Number of nodes in the cluster. Defaults to 1. Note: values greater than 1 will trigger `cluster_type` to switch to `multi-node` | `number` | `1` | no |
@@ -318,6 +320,7 @@ No modules.
 | <a name="output_endpoint_access_id"></a> [endpoint\_access\_id](#output\_endpoint\_access\_id) | The Redshift-managed VPC endpoint name |
 | <a name="output_endpoint_access_port"></a> [endpoint\_access\_port](#output\_endpoint\_access\_port) | The port number on which the cluster accepts incoming connections |
 | <a name="output_endpoint_access_vpc_endpoint"></a> [endpoint\_access\_vpc\_endpoint](#output\_endpoint\_access\_vpc\_endpoint) | The connection endpoint for connecting to an Amazon Redshift cluster through the proxy. See details below |
+| <a name="output_master_password_secret_arn"></a> [master\_password\_secret\_arn](#output\_master\_password\_secret\_arn) | ARN of managed master password secret |
 | <a name="output_parameter_group_arn"></a> [parameter\_group\_arn](#output\_parameter\_group\_arn) | Amazon Resource Name (ARN) of the parameter group created |
 | <a name="output_parameter_group_id"></a> [parameter\_group\_id](#output\_parameter\_group\_id) | The name of the Redshift parameter group created |
 | <a name="output_scheduled_action_iam_role_arn"></a> [scheduled\_action\_iam\_role\_arn](#output\_scheduled\_action\_iam\_role\_arn) | Scheduled actions IAM role ARN |

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -24,14 +24,14 @@ Note that this example may create resources which cost money. Run `terraform des
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.24 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.0 |
-| <a name="provider_aws.us_east_1"></a> [aws.us\_east\_1](#provider\_aws.us\_east\_1) | >= 5.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.24 |
+| <a name="provider_aws.us_east_1"></a> [aws.us\_east\_1](#provider\_aws.us\_east\_1) | >= 5.24 |
 
 ## Modules
 
@@ -89,6 +89,7 @@ No inputs.
 | <a name="output_endpoint_access_id"></a> [endpoint\_access\_id](#output\_endpoint\_access\_id) | The Redshift-managed VPC endpoint name |
 | <a name="output_endpoint_access_port"></a> [endpoint\_access\_port](#output\_endpoint\_access\_port) | The port number on which the cluster accepts incoming connections |
 | <a name="output_endpoint_access_vpc_endpoint"></a> [endpoint\_access\_vpc\_endpoint](#output\_endpoint\_access\_vpc\_endpoint) | The connection endpoint for connecting to an Amazon Redshift cluster through the proxy. See details below |
+| <a name="output_master_password_secret_arn"></a> [master\_password\_secret\_arn](#output\_master\_password\_secret\_arn) | ARN of managed master password secret |
 | <a name="output_parameter_group_arn"></a> [parameter\_group\_arn](#output\_parameter\_group\_arn) | Amazon Resource Name (ARN) of the parameter group created |
 | <a name="output_parameter_group_id"></a> [parameter\_group\_id](#output\_parameter\_group\_id) | The name of the Redshift parameter group created |
 | <a name="output_scheduled_action_iam_role_arn"></a> [scheduled\_action\_iam\_role\_arn](#output\_scheduled\_action\_iam\_role\_arn) | Scheduled actions IAM role ARN |

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -37,10 +37,13 @@ module "redshift" {
   node_type             = "ra3.xlplus"
   number_of_nodes       = 3
 
-  database_name          = "mydb"
-  master_username        = "mydbuser"
-  create_random_password = false
-  master_password        = "MySecretPassw0rd1!" # Do better!
+  database_name   = "mydb"
+  master_username = "mydbuser"
+  # Either provide a good master password
+  #  create_random_password = false
+  #  master_password        = "MySecretPassw0rd1!" # Do better!
+  # Or make Redshift manage it in secrets manager
+  manage_master_password = true
 
   encrypted   = true
   kms_key_arn = aws_kms_key.redshift.arn

--- a/examples/complete/outputs.tf
+++ b/examples/complete/outputs.tf
@@ -209,3 +209,11 @@ output "authentication_profiles" {
   description = "Map of authentication profiles created and their associated attributes"
   value       = module.redshift.authentication_profiles
 }
+
+################################################################################
+# Managed Master Password Secret
+################################################################################
+output "master_password_secret_arn" {
+  description = "ARN of managed master password secret"
+  value       = module.redshift.master_password_secret_arn
+}

--- a/examples/complete/versions.tf
+++ b/examples/complete/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.0"
+      version = ">= 5.24"
     }
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -58,18 +58,20 @@ resource "aws_redshift_cluster" "this" {
     }
   }
 
-  maintenance_track_name           = var.maintenance_track_name
-  manual_snapshot_retention_period = var.manual_snapshot_retention_period
-  master_password                  = var.snapshot_identifier != null ? null : local.master_password
-  master_username                  = var.master_username
-  node_type                        = var.node_type
-  number_of_nodes                  = var.number_of_nodes
-  owner_account                    = var.owner_account
-  port                             = var.port
-  preferred_maintenance_window     = var.preferred_maintenance_window
-  publicly_accessible              = var.publicly_accessible
-  skip_final_snapshot              = var.skip_final_snapshot
-  snapshot_cluster_identifier      = var.snapshot_cluster_identifier
+  maintenance_track_name            = var.maintenance_track_name
+  manual_snapshot_retention_period  = var.manual_snapshot_retention_period
+  manage_master_password            = try(var.manage_master_password, false) ? var.manage_master_password : null
+  master_password                   = var.snapshot_identifier == null && !try(var.manage_master_password, false) ? local.master_password : null
+  master_password_secret_kms_key_id = try(var.master_password_secret_kms_key_id, null)
+  master_username                   = var.master_username
+  node_type                         = var.node_type
+  number_of_nodes                   = var.number_of_nodes
+  owner_account                     = var.owner_account
+  port                              = var.port
+  preferred_maintenance_window      = var.preferred_maintenance_window
+  publicly_accessible               = var.publicly_accessible
+  skip_final_snapshot               = var.skip_final_snapshot
+  snapshot_cluster_identifier       = var.snapshot_cluster_identifier
 
   dynamic "snapshot_copy" {
     for_each = length(var.snapshot_copy) > 0 ? [var.snapshot_copy] : []

--- a/outputs.tf
+++ b/outputs.tf
@@ -213,3 +213,12 @@ output "authentication_profiles" {
   description = "Map of authentication profiles created and their associated attributes"
   value       = aws_redshift_authentication_profile.this
 }
+
+################################################################################
+# Managed Master Password Secret
+################################################################################
+
+output "master_password_secret_arn" {
+  description = "ARN of managed master password secret"
+  value       = try(aws_redshift_cluster.this[0].master_password_secret_arn, null)
+}

--- a/variables.tf
+++ b/variables.tf
@@ -123,6 +123,19 @@ variable "manual_snapshot_retention_period" {
   default     = null
 }
 
+
+variable "manage_master_password" {
+  description = "(Optional) Whether to use AWS SecretsManager to manage the cluster admin credentials. Conflicts with master_password. One of master_password or manage_master_password is required unless snapshot_identifier is provided."
+  type        = bool
+  default     = null
+}
+
+variable "master_password_secret_kms_key_id" {
+  description = "(Optional) ID of the KMS key used to encrypt the cluster admin credentials secret."
+  type        = string
+  default     = null
+}
+
 variable "master_password" {
   description = "Password for the master DB user. (Required unless a `snapshot_identifier` is provided). Must contain at least 8 chars, one uppercase letter, one lowercase letter, and one number"
   type        = string

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.0"
+      version = ">= 5.24"
     }
     random = {
       source  = "hashicorp/random"


### PR DESCRIPTION
## Description
Adds the [`manage_master_password`](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/redshift_cluster#manage_master_password) option to the redshift cluster
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Reduces burden to manage secrets by having Redshift manage it directly.
## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->
No
## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as it's written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
- [x] I have used this in a production upgrade of a redshift cluster
