### PR TITLE
feat: Add `multi_az` support and add `cluster_namespace_arn` 

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,14 +179,14 @@ module "redshift" {
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.25 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.35 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.25 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.35 |
 | <a name="provider_random"></a> [random](#provider\_random) | >= 3.0 |
 
 ## Modules
@@ -306,6 +306,7 @@ No modules.
 | <a name="output_cluster_hostname"></a> [cluster\_hostname](#output\_cluster\_hostname) | The hostname of the Redshift cluster |
 | <a name="output_cluster_id"></a> [cluster\_id](#output\_cluster\_id) | The Redshift cluster ID |
 | <a name="output_cluster_identifier"></a> [cluster\_identifier](#output\_cluster\_identifier) | The Redshift cluster identifier |
+| <a name="output_cluster_namespace_arn"></a> [cluster\_namespace\_arn](#output\_cluster\_namespace\_arn) | The namespace Amazon Resource Name (ARN) of the cluster |
 | <a name="output_cluster_node_type"></a> [cluster\_node\_type](#output\_cluster\_node\_type) | The type of nodes in the cluster |
 | <a name="output_cluster_nodes"></a> [cluster\_nodes](#output\_cluster\_nodes) | The nodes in the cluster. Each node is a map of the following attributes: `node_role`, `private_ip_address`, and `public_ip_address` |
 | <a name="output_cluster_parameter_group_name"></a> [cluster\_parameter\_group\_name](#output\_cluster\_parameter\_group\_name) | The name of the parameter group to be associated with this cluster |

--- a/README.md
+++ b/README.md
@@ -179,14 +179,14 @@ module "redshift" {
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.24 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.25 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.24 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.25 |
 | <a name="provider_random"></a> [random](#provider\_random) | >= 3.0 |
 
 ## Modules
@@ -260,6 +260,7 @@ No modules.
 | <a name="input_master_password"></a> [master\_password](#input\_master\_password) | Password for the master DB user. (Required unless a `snapshot_identifier` is provided). Must contain at least 8 chars, one uppercase letter, one lowercase letter, and one number | `string` | `null` | no |
 | <a name="input_master_password_secret_kms_key_id"></a> [master\_password\_secret\_kms\_key\_id](#input\_master\_password\_secret\_kms\_key\_id) | ID of the KMS key used to encrypt the cluster admin credentials secret | `string` | `null` | no |
 | <a name="input_master_username"></a> [master\_username](#input\_master\_username) | Username for the master DB user (Required unless a `snapshot_identifier` is provided). Defaults to `awsuser` | `string` | `"awsuser"` | no |
+| <a name="input_multi_az"></a> [multi\_az](#input\_multi\_az) | Specifies if the Redshift cluster is multi-AZ | `bool` | `null` | no |
 | <a name="input_node_type"></a> [node\_type](#input\_node\_type) | The node type to be provisioned for the cluster | `string` | `""` | no |
 | <a name="input_number_of_nodes"></a> [number\_of\_nodes](#input\_number\_of\_nodes) | Number of nodes in the cluster. Defaults to 1. Note: values greater than 1 will trigger `cluster_type` to switch to `multi-node` | `number` | `1` | no |
 | <a name="input_owner_account"></a> [owner\_account](#input\_owner\_account) | The AWS customer account used to create or copy the snapshot. Required if you are restoring a snapshot you do not own, optional if you own the snapshot | `string` | `null` | no |

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -24,14 +24,14 @@ Note that this example may create resources which cost money. Run `terraform des
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.24 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.35 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.24 |
-| <a name="provider_aws.us_east_1"></a> [aws.us\_east\_1](#provider\_aws.us\_east\_1) | >= 5.24 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.35 |
+| <a name="provider_aws.us_east_1"></a> [aws.us\_east\_1](#provider\_aws.us\_east\_1) | >= 5.35 |
 
 ## Modules
 

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -74,6 +74,7 @@ No inputs.
 | <a name="output_cluster_hostname"></a> [cluster\_hostname](#output\_cluster\_hostname) | The hostname of the Redshift cluster |
 | <a name="output_cluster_id"></a> [cluster\_id](#output\_cluster\_id) | The Redshift cluster ID |
 | <a name="output_cluster_identifier"></a> [cluster\_identifier](#output\_cluster\_identifier) | The Redshift cluster identifier |
+| <a name="output_cluster_namespace_arn"></a> [cluster\_namespace\_arn](#output\_cluster\_namespace\_arn) | The namespace Amazon Resource Name (ARN) of the cluster |
 | <a name="output_cluster_node_type"></a> [cluster\_node\_type](#output\_cluster\_node\_type) | The type of nodes in the cluster |
 | <a name="output_cluster_nodes"></a> [cluster\_nodes](#output\_cluster\_nodes) | The nodes in the cluster. Each node is a map of the following attributes: `node_role`, `private_ip_address`, and `public_ip_address` |
 | <a name="output_cluster_parameter_group_name"></a> [cluster\_parameter\_group\_name](#output\_cluster\_parameter\_group\_name) | The name of the parameter group to be associated with this cluster |

--- a/examples/complete/outputs.tf
+++ b/examples/complete/outputs.tf
@@ -107,6 +107,11 @@ output "cluster_nodes" {
   value       = module.redshift.cluster_nodes
 }
 
+output "cluster_namespace_arn" {
+  description = "The namespace Amazon Resource Name (ARN) of the cluster"
+  value       = module.redshift.cluster_namespace_arn
+}
+
 ################################################################################
 # Parameter Group
 ################################################################################

--- a/examples/complete/versions.tf
+++ b/examples/complete/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.24"
+      version = ">= 5.35"
     }
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -64,7 +64,7 @@ resource "aws_redshift_cluster" "this" {
   master_password                   = var.snapshot_identifier == null && !var.manage_master_password ? local.master_password : null
   master_password_secret_kms_key_id = var.master_password_secret_kms_key_id
   master_username                   = var.master_username
-  multi_az                          = var.number_of_nodes > 1 ? var.multi_az : null
+  multi_az                          = var.multi_az
   node_type                         = var.node_type
   number_of_nodes                   = var.number_of_nodes
   owner_account                     = var.owner_account

--- a/main.tf
+++ b/main.tf
@@ -64,6 +64,7 @@ resource "aws_redshift_cluster" "this" {
   master_password                   = var.snapshot_identifier == null && !var.manage_master_password ? local.master_password : null
   master_password_secret_kms_key_id = var.master_password_secret_kms_key_id
   master_username                   = var.master_username
+  multi_az                          = var.number_of_nodes > 1 ? var.multi_az : null
   node_type                         = var.node_type
   number_of_nodes                   = var.number_of_nodes
   owner_account                     = var.owner_account

--- a/outputs.tf
+++ b/outputs.tf
@@ -111,6 +111,11 @@ output "cluster_nodes" {
   value       = try(aws_redshift_cluster.this[0].cluster_nodes, {})
 }
 
+output "cluster_namespace_arn" {
+  description = "The namespace Amazon Resource Name (ARN) of the cluster"
+  value       = try(aws_redshift_cluster.this[0].cluster_namespace_arn, null)
+}
+
 ################################################################################
 # Parameter Group
 ################################################################################

--- a/variables.tf
+++ b/variables.tf
@@ -143,6 +143,12 @@ variable "master_password" {
   sensitive   = true
 }
 
+variable "multi_az" {
+  description = "Specifies if the Redshift cluster is multi-AZ"
+  type        = bool
+  default     = null
+}
+
 variable "create_random_password" {
   description = "Determines whether to create random password for cluster `master_password`"
   type        = bool

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.24"
+      version = ">= 5.35"
     }
 
     random = {


### PR DESCRIPTION
## Description
Adds `multi_az` support. 
Adds `cluster_namespace_arn` attribute. 

## Motivation and Context
https://github.com/hashicorp/terraform-provider-aws/pull/35508
Closes: https://github.com/terraform-aws-modules/terraform-aws-redshift/issues/92

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
