### PR TITLE
feat: Logging and Snapshot copy resources converted to standalone resource equivalents, MSV of Terraform raised to `v1.3`

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,14 +179,14 @@ module "redshift" {
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.35 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.45 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.35 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.45 |
 | <a name="provider_random"></a> [random](#provider\_random) | >= 3.0 |
 
 ## Modules
@@ -204,8 +204,10 @@ No modules.
 | [aws_redshift_cluster.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/redshift_cluster) | resource |
 | [aws_redshift_cluster_iam_roles.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/redshift_cluster_iam_roles) | resource |
 | [aws_redshift_endpoint_access.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/redshift_endpoint_access) | resource |
+| [aws_redshift_logging.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/redshift_logging) | resource |
 | [aws_redshift_parameter_group.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/redshift_parameter_group) | resource |
 | [aws_redshift_scheduled_action.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/redshift_scheduled_action) | resource |
+| [aws_redshift_snapshot_copy.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/redshift_snapshot_copy) | resource |
 | [aws_redshift_snapshot_schedule.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/redshift_snapshot_schedule) | resource |
 | [aws_redshift_snapshot_schedule_association.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/redshift_snapshot_schedule_association) | resource |
 | [aws_redshift_subnet_group.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/redshift_subnet_group) | resource |

--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ module "redshift" {
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.45 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.0 |
 

--- a/UPGRADE-6.0.md
+++ b/UPGRADE-6.0.md
@@ -59,7 +59,7 @@ Please consult the `examples` directory for reference example configurations. If
 ```hcl
 module "redshift" {
   source  = "terraform-aws-modules/redshift/aws"
-  version = "5.4.0"
+  version = "~> 5.0"
 
   snapshot_copy = {
     destination_region = "us-east-1"
@@ -79,7 +79,7 @@ module "redshift" {
 ```hcl
 module "redshift" {
   source  = "terraform-aws-modules/redshift/aws"
-  version = "6.0.0"
+  version = "~> 6.0"
 
   snapshot_copy = {
     destination_region = "us-east-1"

--- a/UPGRADE-6.0.md
+++ b/UPGRADE-6.0.md
@@ -1,0 +1,131 @@
+# Upgrade from v5.x to v6.x
+
+Please consult the `examples` directory for reference example configurations. If you find a bug, please open an issue with supporting configuration to reproduce.
+
+## List of backwards incompatible changes
+
+- Minimum supported version of Terraform AWS provider updated to v5.45 to support latest resources
+- logging block within the `aws_redshift_cluster` resource has been replaced with a standalone resource. After upgrade, a new resource for logging will be created.
+- snapshot_copy block within the `aws_redshift_cluster` resource has been replaced with a standalone resource. After upgrade, to prevent errors due to already existing `snapshot_copy` configurations, import of the new resource is required.
+
+## Additional changes
+
+### Added
+
+- `aws_redshift_logging` has been added to replace `logging` block in `aws_redshift_cluster`
+- `aws_redshift_snapshot_copy` has been added to replace `snapshot_copy` block in `aws_redshift_cluster`
+
+### Modified
+
+- None
+
+### Removed
+
+- `logging` block in `aws_redshift_cluster`
+- `snapshot_copy` block in `aws_redshift_cluster`
+
+### Variable and output changes
+
+1. Removed variables:
+
+  - Cluster
+    - `var.logging.enable` has been removed
+
+2. Renamed variables:
+
+  - None
+
+3. Added variables:
+
+  - Snapshot Copy
+    - `var.snapshot_copy.manual_snapshot_retention_period`
+
+4. Removed outputs:
+
+  - None
+
+5. Renamed outputs:
+
+  - None
+
+6. Added outputs:
+
+  - None
+
+## Upgrade Migration
+
+### Before v5.x Example
+
+```hcl
+module "redshift" {
+  source  = "terraform-aws-modules/redshift/aws"
+  version = "5.4.0"
+
+  snapshot_copy = {
+    destination_region = "us-east-1"
+    grant_name         = aws_redshift_snapshot_copy_grant.useast1.snapshot_copy_grant_name
+  }
+
+  logging = {
+    enable        = true
+    bucket_name   = module.s3_logs.s3_bucket_id
+    s3_key_prefix = local.s3_prefix
+  }
+}
+```
+
+### After v6.x Example
+
+```hcl
+module "redshift" {
+  source  = "terraform-aws-modules/redshift/aws"
+  version = "6.0.0"
+
+  snapshot_copy = {
+    destination_region = "us-east-1"
+    grant_name         = aws_redshift_snapshot_copy_grant.useast1.snapshot_copy_grant_name
+  }
+
+  logging = {
+    bucket_name   = module.s3_logs.s3_bucket_id
+    s3_key_prefix = local.s3_prefix
+  }
+}
+```
+
+### Diff of Before vs After
+
+```diff
+  # module.redshift.aws_redshift_logging.this[0] will be created
+  + resource "aws_redshift_logging" "this" {
+      + bucket_name        = "ex-complete20240414012816938100000003"
+      + cluster_identifier = "ex-complete"
+      + id                 = (known after apply)
+      + s3_key_prefix      = "redshift/ex-complete/"
+    }
+
+  # module.redshift.aws_redshift_snapshot_copy.this[0] will be created
+  + resource "aws_redshift_snapshot_copy" "this" {
+      + cluster_identifier               = "ex-complete"
+      + destination_region               = "us-east-1"
+      + id                               = (known after apply)
+      + manual_snapshot_retention_period = (known after apply)
+      + retention_period                 = (known after apply)
+      + snapshot_copy_grant_name         = "ex-complete-us-east-1"
+    }
+```
+The `aws_redshift_logging` can be applied or imported. If setting the `log_destination_type`, an apply following an import will be required to clear the remaining diff.
+The `aws_redshift_snapshot_copy` resource requires importing if an existing snapshot_copy configuration exists.
+
+### State Move Commands
+
+None required
+
+### State Import Commands
+
+During the migration to v6.x of this module, logging and snapshot_copy resources will be created by this module if those settings are configured. In order to guarantee the best experience and prevent data loss, you will need to import them into terraform state using commands like these:
+
+```bash
+terraform import 'module.redshift.aws_redshift_logging.this[0]' <cluster-id>
+terraform import 'module.redshift.aws_redshift_snapshot_copy.this[0]' <cluster-id>
+```

--- a/UPGRADE-6.0.md
+++ b/UPGRADE-6.0.md
@@ -4,7 +4,8 @@ Please consult the `examples` directory for reference example configurations. If
 
 ## List of backwards incompatible changes
 
-- Minimum supported version of Terraform AWS provider updated to v5.45 to support latest resources
+- Minimum supported version of Terraform AWS provider updated to `v5.45` to support latest resources
+- Minimum supported version of Terraform raised to `v1.3`
 - logging block within the `aws_redshift_cluster` resource has been replaced with a standalone resource. After upgrade, a new resource for logging will be created.
 - snapshot_copy block within the `aws_redshift_cluster` resource has been replaced with a standalone resource. After upgrade, to prevent errors due to already existing `snapshot_copy` configurations, import of the new resource is required.
 

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -23,7 +23,7 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.45 |
 
 ## Providers

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -24,14 +24,14 @@ Note that this example may create resources which cost money. Run `terraform des
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.35 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.45 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.35 |
-| <a name="provider_aws.us_east_1"></a> [aws.us\_east\_1](#provider\_aws.us\_east\_1) | >= 5.35 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.45 |
+| <a name="provider_aws.us_east_1"></a> [aws.us\_east\_1](#provider\_aws.us\_east\_1) | >= 5.45 |
 
 ## Modules
 

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -64,7 +64,6 @@ module "redshift" {
   }
 
   logging = {
-    enable        = true
     bucket_name   = module.s3_logs.s3_bucket_id
     s3_key_prefix = local.s3_prefix
   }
@@ -221,7 +220,6 @@ module "with_cloudwatch_logging" {
   create_cloudwatch_log_group            = true
   cloudwatch_log_group_retention_in_days = 7
   logging = {
-    enable               = true
     log_destination_type = "cloudwatch"
     log_exports          = ["connectionlog", "userlog", "useractivitylog"]
   }

--- a/examples/complete/versions.tf
+++ b/examples/complete/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.0"
+  required_version = ">= 1.3"
 
   required_providers {
     aws = {

--- a/examples/complete/versions.tf
+++ b/examples/complete/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.35"
+      version = ">= 5.45"
     }
   }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.0"
+  required_version = ">= 1.3"
 
   required_providers {
     aws = {

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.35"
+      version = ">= 5.45"
     }
 
     random = {


### PR DESCRIPTION
## Description
Add `aws_redshift_logging` and `aws_redshift_snapshot_copy` resources and removed deprecated configuration blocks for `aws_redshift_cluster.logging` and `aws_redshift_cluster.snapshot_copy`. 

## Motivation and Context
https://github.com/hashicorp/terraform-provider-aws/pull/36862
https://github.com/hashicorp/terraform-provider-aws/pull/36810

## Breaking Changes
Yes. New logging and snapshot copy resources replace existing deprecated `logging` and `snapshot_copy` blocks in `aws_redshift_cluster`. 

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
