### PR TITLE
chore: Remove `enable` from logging in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,6 @@ module "redshift" {
   }
 
   logging = {
-    enable        = true
     bucket_name   = "my-s3-log-bucket"
     s3_key_prefix = "example/"
   }


### PR DESCRIPTION
## Description
Remove `enable` from logging in README.md

## Motivation and Context
Per [last update](https://github.com/terraform-aws-modules/terraform-aws-redshift/pull/99), the `enable` option has been removed and we should update the README file as well

## Breaking Changes
No breaking changes

## How Has This Been Tested?
No function changed
