### PR TITLE
feat: Allow parameter group key to be used as parameter group `name`, add outputs for cluster master password and username

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,6 +319,8 @@ No modules.
 | <a name="output_cluster_hostname"></a> [cluster\_hostname](#output\_cluster\_hostname) | The hostname of the Redshift cluster |
 | <a name="output_cluster_id"></a> [cluster\_id](#output\_cluster\_id) | The Redshift cluster ID |
 | <a name="output_cluster_identifier"></a> [cluster\_identifier](#output\_cluster\_identifier) | The Redshift cluster identifier |
+| <a name="output_cluster_master_password"></a> [cluster\_master\_password](#output\_cluster\_master\_password) | The Redshift cluster master password |
+| <a name="output_cluster_master_username"></a> [cluster\_master\_username](#output\_cluster\_master\_username) | The Redshift cluster master username |
 | <a name="output_cluster_namespace_arn"></a> [cluster\_namespace\_arn](#output\_cluster\_namespace\_arn) | The namespace Amazon Resource Name (ARN) of the cluster |
 | <a name="output_cluster_node_type"></a> [cluster\_node\_type](#output\_cluster\_node\_type) | The type of nodes in the cluster |
 | <a name="output_cluster_nodes"></a> [cluster\_nodes](#output\_cluster\_nodes) | The nodes in the cluster. Each node is a map of the following attributes: `node_role`, `private_ip_address`, and `public_ip_address` |

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -75,6 +75,8 @@ No inputs.
 | <a name="output_cluster_hostname"></a> [cluster\_hostname](#output\_cluster\_hostname) | The hostname of the Redshift cluster |
 | <a name="output_cluster_id"></a> [cluster\_id](#output\_cluster\_id) | The Redshift cluster ID |
 | <a name="output_cluster_identifier"></a> [cluster\_identifier](#output\_cluster\_identifier) | The Redshift cluster identifier |
+| <a name="output_cluster_master_password"></a> [cluster\_master\_password](#output\_cluster\_master\_password) | The Redshift cluster master password |
+| <a name="output_cluster_master_username"></a> [cluster\_master\_username](#output\_cluster\_master\_username) | The Redshift cluster master username |
 | <a name="output_cluster_namespace_arn"></a> [cluster\_namespace\_arn](#output\_cluster\_namespace\_arn) | The namespace Amazon Resource Name (ARN) of the cluster |
 | <a name="output_cluster_node_type"></a> [cluster\_node\_type](#output\_cluster\_node\_type) | The type of nodes in the cluster |
 | <a name="output_cluster_nodes"></a> [cluster\_nodes](#output\_cluster\_nodes) | The nodes in the cluster. Each node is a map of the following attributes: `node_role`, `private_ip_address`, and `public_ip_address` |

--- a/examples/complete/outputs.tf
+++ b/examples/complete/outputs.tf
@@ -112,6 +112,16 @@ output "cluster_namespace_arn" {
   value       = module.redshift.cluster_namespace_arn
 }
 
+output "cluster_master_password" {
+  description = "The Redshift cluster master password"
+  value       = module.redshift.cluster_master_password
+}
+
+output "cluster_master_username" {
+  description = "The Redshift cluster master username"
+  value       = module.redshift.cluster_master_username
+}
+
 ################################################################################
 # Parameter Group
 ################################################################################

--- a/outputs.tf
+++ b/outputs.tf
@@ -116,6 +116,18 @@ output "cluster_namespace_arn" {
   value       = try(aws_redshift_cluster.this[0].cluster_namespace_arn, null)
 }
 
+output "cluster_master_password" {
+  description = "The Redshift cluster master password"
+  value       = try(aws_redshift_cluster.this[0].master_password, null)
+  sensitive   = true
+}
+
+output "cluster_master_username" {
+  description = "The Redshift cluster master username"
+  value       = try(aws_redshift_cluster.this[0].master_username, null)
+  sensitive   = true
+}
+
 ################################################################################
 # Parameter Group
 ################################################################################

--- a/wrappers/outputs.tf
+++ b/wrappers/outputs.tf
@@ -1,5 +1,5 @@
 output "wrapper" {
   description = "Map of outputs of a wrapper."
   value       = module.wrapper
-  # sensitive = false # No sensitive module output found
+  sensitive   = true # At least one sensitive module output (cluster_master_password) found (requires Terraform 0.14+)
 }


### PR DESCRIPTION
## Description
- Allow parameter group key to be used as parameter group `name`
- Add outputs for `cluster_master_password` and `cluster_master_username`

## Motivation and Context
- Resolves #106
- Resolves #107

## Breaking Changes
- No

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
